### PR TITLE
Allows for early versions of TU Access IDS

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,7 +6,6 @@ class Account < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :trackable, :timeoutable, :omniauthable, :database_authenticatable
- 	validates :email, tu_access_email: true
 
   def self.from_omniauth(access_token)
     data = access_token.info

--- a/app/models/concerns/validators.rb
+++ b/app/models/concerns/validators.rb
@@ -8,14 +8,6 @@ module Validators
     end
   end
 
-  class TuAccessEmailValidator < ActiveModel::EachValidator
-    def validate_each(record, attribute, value)
-      unless value =~ /\Atu[a-z]\d{5}@temple\.edu\z/i
-        record.errors[attribute] << (options[:message] || "is not an acceptable email address")
-      end
-    end
-  end
-
   class PhoneNumberValidator < ActiveModel::EachValidator
     def validate_each(record, attribute, value)
       unless value =~ /\d{10}/i


### PR DESCRIPTION
Cannot restrict to current TU Access ID format. It has to accommodate whatever will be returned from Google Authentication.