### PR TITLE
Adds a FuzzyFinderService that can be used to add find similar strings in attributes for a given model. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "administrate"
 gem 'bootstrap', '~> 4.1.0'
 gem 'tinymce-rails'
 gem 'google-api-client', '~> 0.11'
-
+gem 'fuzzy_match'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
     ffaker (2.10.0)
     ffi (1.9.25)
     formatador (0.2.5)
+    fuzzy_match (2.1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     google-api-client (0.23.9)
@@ -459,6 +460,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  fuzzy_match
   google-api-client (~> 0.11)
   guard-rspec
   jbuilder (~> 2.5)
@@ -491,4 +493,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/app/services/fuzzy_finder_service.rb
+++ b/app/services/fuzzy_finder_service.rb
@@ -1,0 +1,109 @@
+module FuzzyFinderService
+
+  require 'fuzzy_match'
+
+  class Error < StandardError; end
+
+  # FuzzyFinderService takes a string tries to find the best match
+  # for that string in the attribute (name by default) of a given model.
+  # For example FuzzyFinderService.call(needle: "Joe Schmoe", haystack_model: Person)
+  #  will return the Person object for "Joseph Schmoe".
+  # or using another attribute
+  # FuzzyFinderService.call(needle: "joe@schmoe.com", haystack_model: Person, attribute: :email_address)
+  # It is useful when you want to connect data coming from external systems
+  # to records in the DB.
+  # You can also filter further with additional paramters
+  # Say you know the group the person is in as well, to help disambiguate
+  # g = Group.find_by(name: "Piano Players")
+  # Pass that group along with the association attribute for the Person mode as addl_attribute
+  # p = FuzzyFinderService.call(needle: "Jon Smith", haystack_model: Person, addl_attribute: {groups: g })
+  # p.name
+  # > "Jon Smith"
+  # p.groups
+  # > [#<Group:0x00007fb560170690, id: 1, name: "Piano Players",...]
+  #
+  # @param needle [String] the string you want to match, `Joe Schmoe`
+  # @param haystack_model [Class] the model to search against,`Person`
+  # @param attribute [String, Symbol] model attribute to match against.
+  #   Association attributes will not work, `email_address`
+  # @param addl_attribute [Hash]  Additional attribute and value to filter by.
+  #   Can include Associations. `{groups: groupObject }` or `{groups}`
+  # @option addl_attribute [Object, String, Integer] :attribute_
+  # @return [String] the object converted into the expected format.
+  def self.call(needle: ,haystack_model:, attribute: :name, addl_attribute: {})
+    Finder.new(haystack_model: haystack_model, attribute: attribute, addl_attribute: addl_attribute)
+      .find(needle)
+  end
+
+  class Finder
+
+    def initialize(haystack_model:, attribute: nil, addl_attribute: {})
+        @model = ensure_is_a_class_name(haystack_model)
+        validate_is_a_defined_active_model!
+        @attribute =  attribute
+        @addl_attribute = format_addl_attribute(addl_attribute)
+    end
+
+    def find(needle)
+      matcher.find(needle)
+    end
+
+    private
+      attr_reader :model, :attribute, :addl_attribute
+
+      def ensure_is_a_class_name(model)
+        model.is_a?(Class) ? model : model.to_s.classify.constantize
+      end
+
+      def validate_is_a_defined_active_model!
+        #Eager load classes if not in production (is already
+        # done in production) so ApplicationRecord.descendants works
+        Rails.application.eager_load! unless Rails.env.production?
+        raise FuzzyFinderService::Error.new(
+          "#{model} is not an ActiveModel in this application"
+        ) unless ApplicationRecord.descendants.include? model
+      end
+
+      def model_query
+        if attribute_is_has_many_through?(addl_attribute)
+          model.joins(addl_attribute.key).where(addl_attribute.key => {id: pick_addl_attribute_value})
+        else
+          model.where(addl_attribute.to_h)
+        end
+      end
+
+      def format_addl_attribute(addl_attribute)
+        return addl_attribute if addl_attribute.empty?
+        AddlAttribute.new([:key, :value].zip(addl_attribute.first).to_h)
+      end
+
+      def pick_addl_attribute_value
+        # If the value is an object, grab the id, otherwise return the value
+        addl_attribute.value.respond_to?(:model_name) ? addl_attribute.value.id : addl_attribute.value
+      end
+
+      def attribute_is_has_many_through?(attribute)
+        return false if attribute.is_a? Hash
+        # this returns nil if the attribute is not an association
+        model.reflect_on_association(attribute.key)
+          &.association_class == ActiveRecord::Associations::HasManyThroughAssociation
+      end
+
+      def options
+        {
+          must_match_at_least_one_word: true,
+          read: attribute.to_sym
+        }
+      end
+
+      def matcher
+        @matcher ||= FuzzyMatch.new(model_query, options)
+      end
+
+      class AddlAttribute < OpenStruct
+        def to_h
+          {key => value}
+        end
+      end
+  end
+end

--- a/spec/services/fuzzy_finder_service_spec.rb
+++ b/spec/services/fuzzy_finder_service_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe FuzzyFinderService do
+
+  class UndefinedModel; end
+  class MockModel < ApplicationRecord
+    #Stub this since we don't actually have a table for this
+    def self.where(args)
+      []
+    end
+  end
+
+  let(:needle) {"thing_to_search_for"}
+  let(:haystack_model) { MockModel }
+  let(:attribute) { :name }
+  let(:called_service) {
+    described_class.call(
+      needle: needle,
+      haystack_model: haystack_model,
+      attribute: attribute
+    )
+  }
+
+  it 'responds to #call' do
+    expect(described_class).to respond_to :call
+  end
+
+  describe '#call' do
+    it 'throws an error if needle param is not supplied' do
+      expect { described_class.call(haystack_model: MockModel)}.to raise_error(ArgumentError)
+    end
+
+    it 'throws an error if haystack_model param is not supplied' do
+      expect {described_class.call(needle: "thing_to_find") }.to raise_error(ArgumentError)
+    end
+
+    it 'can be called without attribute argument' do
+      expect {
+        described_class.call(needle: needle, haystack_model: haystack_model)
+        }.to_not raise_error
+    end
+
+    it 'can accept an attribute argument' do
+      expect{ called_service }.not_to raise_error
+    end
+
+    context 'haystack_model is not a defined model' do
+      let(:haystack_model) { UndefinedModel }
+      it 'raises a FuzzyFinderService Error' do
+        expect { called_service }.to raise_error(FuzzyFinderService::Error)
+      end
+    end
+
+    context 'search for a person' do
+      before do
+        building = FactoryBot.create(:building)
+        @space = FactoryBot.create(:space, building: building)
+        FactoryBot.create(:person, spaces: [@space])
+        @group = FactoryBot.create(:group, spaces: [@space], chair_dept_head: Person.take(1).first)
+
+        @new_person = Person.create!(
+          first_name: "New", last_name: "Person",
+          phone_number: "1234567890",
+          email_address: "new.person@temple.edu",
+          groups: [@group], spaces: [@space],
+          job_title: "FooBarbarian")
+      end
+
+      context 'with a similar name' do
+        it 'returns the expected person' do
+          expect(FuzzyFinderService.call(
+            needle: "Newish Person",
+            haystack_model: Person,
+            attribute: :name)
+          ).to eql @new_person
+        end
+
+        context 'and an simple additional attribute' do
+          it 'returns the expected person' do
+            expect(
+              FuzzyFinderService.call(
+                needle: "Newish Person",
+                haystack_model: Person,
+                attribute: :name,
+                addl_attribute: {email_address: "new.person@temple.edu"}
+              )
+            ).to eql @new_person
+          end
+        end
+
+        context 'and an association additional attribute' do
+          context 'passing an object' do
+            it 'returns the expected person' do
+              expect(
+                FuzzyFinderService.call(
+                  needle: "Newish Person",
+                  haystack_model: Person,
+                  attribute: :name,
+                  addl_attribute: {groups: @group}
+                )
+              ).to eql @new_person
+            end
+          end
+
+          context 'passing an id string' do
+            it 'returns the expected person' do
+              expect(
+                FuzzyFinderService.call(
+                  needle: "Newish Person",
+                  haystack_model: Person,
+                  attribute: :name,
+                  addl_attribute: {groups: "1"}
+                )
+              ).to eql @new_person
+            end
+          end
+
+          context 'passing an id int' do
+            it 'returns the expected person' do
+              expect(
+                FuzzyFinderService.call(
+                  needle: "Newish Person",
+                  haystack_model: Person,
+                  attribute: :name,
+                  addl_attribute: {groups: 1}
+                )
+              ).to eql @new_person
+            end
+          end
+        end
+      end
+
+      context 'with a name that does not match at all' do
+        it 'returns nil' do
+          expect(FuzzyFinderService.call(
+            needle: "kikkilij mqwwewe",
+            haystack_model: Person,
+            attribute: :name)
+          ).to eql nil
+        end
+      end
+
+
+      after do
+        DatabaseCleaner.clean
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the FuzzyMatch gem under the hood, which uses the dice coefficient and  levenshtein distance algorithms.

Will help to identify records in our database with exterbal systems, like blogs, events, etc.

For example, blog feeds include a person's name as the Author, but spelling may vary slighty (Joe vs Joeseph, missing middle names, etc.). This will allow us to connect programmatically imported records to existing DB records and people.