### PR TITLE
Create Event Sync Service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem "cancancan", "~> 2.0"
 gem "listen", ">= 3.0.5", "< 3.2"
 gem "yaml_db"
 gem "auto_strip_attributes"
+gem "nokogiri"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,6 +474,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)
   mutant-rspec
+  nokogiri
   omniauth
   omniauth-google-oauth2
   populate

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  belongs_to :building
-  belongs_to :space
-  belongs_to :person
+  belongs_to :building, optional: true
+  belongs_to :space, optional: true
+  belongs_to :person, optional: true
 end

--- a/app/services/sync_events.rb
+++ b/app/services/sync_events.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "open-uri"
+require "nokogiri"
+require "pry"
+
+class SyncEvents
+  def initialize(params = [])
+    @eventsUrl = params.fetch(:events_url, "https://events.temple.edu/feed/xml/events?department=2566")
+    @eventsDoc = ""
+  end
+
+  def read_events
+    @eventsDoc = Nokogiri::XML(open(@eventsUrl))
+    events = @eventsDoc.xpath("//Events/Event").map
+    @events = events.map do |e|
+      event = Hash.new
+      e.elements.each do |ele|
+        event[ele.name] = ele.content
+      end
+      event
+    end
+  end
+
+  def record_hash(event)
+    event_hash = {
+      "title" => event.fetch("Title", I18n.t("fortytude.default.event.title")),
+      "description" => event.fetch("Description",  I18n.t("fortytude.default.event.description")),
+      "cancelled" => event.fetch("Canceled", 0),
+      "registration_status" => event.fetch("RegistrationStatus", I18n.t("fortytude.default.event.registration_status")),
+      "registration_link" => event.fetch("RegistrationLink", "#"),
+    }
+
+    start_time = [event.fetch("EventStartDate", ""), event.fetch("EventStartTime", "")].join(" ")
+    event_hash["start_time"] = Time.parse("#{start_time}").to_s
+
+    end_time = [event.fetch("EventEndDate", ""), event.fetch("EventEndTime", "")].join(" ")
+    event_hash["end_time"] = Time.parse("#{end_time}").to_s
+
+    contact_name = event.fetch("ContactName") { I18n.t("fortytude.default.event.contact_name") }
+    contact_person = FuzzyFinderService.call(
+      needle: contact_name,
+      haystack_model: Person,
+      attribute: :name)
+    unless contact_person.nil?
+      event_hash["person"] = contact_person
+    else
+      event_hash["external_contact_name"]  = contact_name
+      event_hash["external_contact_email"] = event.fetch("ContactEmail") { I18n.t("fortytude.default.event.contact_email") }
+      event_hash["external_contact_phone"] = event.fetch("ContactPhone") { I18n.t("fortytude.default.event.contact_phone") }
+    end
+
+    location = event.fetch("Location") { I18n.t("fortytude.default.event.building") }
+    building = FuzzyFinderService.call(
+      needle: location,
+      haystack_model: Building,
+      attribute: :name)
+    unless building.nil?
+      event_hash["building"] = building
+    else
+      event_hash["external_building"] = location
+      event_hash["external_address"] = event.fetch("Address") { I18n.t("fortytude.default.event.external_address") }
+      event_hash["external_city"] = event.fetch("City") { I18n.t("fortytude.default.event.external_city") }
+      event_hash["external_state"] = event.fetch("State") { I18n.t("fortytude.default.event.external_state") }
+      event_hash["external_zip"] = event.fetch("Zip") { I18n.t("fortytude.default.event.external_zip") }
+    end
+
+    room = event.fetch("Room") { I18n.t("fortytude.default.event.space") }
+    space = FuzzyFinderService.call(
+      needle: room,
+      haystack_model: Space,
+      attribute: :name)
+    unless space.nil?
+      event_hash["space"] = space
+    else
+      event_hash["external_space"] = room
+    end
+
+    event_hash["content_hash"] = Digest::SHA1.hexdigest(event.to_xml)
+
+    event_hash
+  end
+
+  def sync
+    events = read_events
+    events.each do |e|
+      params = record_hash(e)
+      event = Event.create(params.except ["person", "building"])
+      event.person = params["person"]
+      event.building = params["building"]
+      event.save!
+    end
+  end
+end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,25 +6,10 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Description</th>
       <th>Start time</th>
       <th>End time</th>
       <th>Building</th>
       <th>Space</th>
-      <th>External building</th>
-      <th>External space</th>
-      <th>External address</th>
-      <th>External city</th>
-      <th>External state</th>
-      <th>External zip</th>
-      <th>Person</th>
-      <th>External contact name</th>
-      <th>External contact email</th>
-      <th>External contact phone</th>
-      <th>Cancelled</th>
-      <th>Registration status</th>
-      <th>Registration link</th>
-      <th>Content hash</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -33,25 +18,15 @@
     <% @events.each do |event| %>
       <tr>
         <td><%= event.title %></td>
-        <td><%= event.description %></td>
         <td><%= event.start_time %></td>
         <td><%= event.end_time %></td>
-        <td><%= event.building.name %></td>
-        <td><%= event.space.name %></td>
-        <td><%= event.external_building %></td>
-        <td><%= event.external_space %></td>
-        <td><%= event.external_address %></td>
-        <td><%= event.external_city %></td>
-        <td><%= event.external_state %></td>
-        <td><%= event.external_zip %></td>
-        <td><%= event.person.first_name %> <%= event.person.last_name %></td>
-        <td><%= event.external_contact_name %></td>
-        <td><%= event.external_contact_email %></td>
-        <td><%= event.external_contact_phone %></td>
-        <td><%= event.cancelled %></td>
-        <td><%= event.registration_status %></td>
-        <td><%= event.registration_link %></td>
-        <td><%= event.content_hash %></td>
+        <% unless event.building.nil? %>
+          <td><%= event.building.name %></td>
+          <td><%= event.space.name unless event.space.nil? %></td>
+        <% else %>
+          <td><%= event.external_building %></td>
+          <td><%= event.external_space %></td>
+        <% end %>
         <td><%= link_to 'Show', event %></td>
       </tr>
     <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,15 +20,19 @@
   <%= @event.end_time %>
 </p>
 
-<p>
-  <strong>Building:</strong>
-  <%= @event.building.name %>
-</p>
+<% unless @event.building.nil? %>
+  <p>
+    <strong>Building:</strong>
+    <%= @event.building.name %>
+  </p>
+<% end %>
 
-<p>
-  <strong>Space:</strong>
-  <%= @event.space.name %>
-</p>
+<% unless @event.space.nil? %>
+  <p>
+    <strong>Space:</strong>
+    <%= @event.space.name %>
+  </p>
+<% end %>
 
 <p>
   <strong>External building:</strong>
@@ -60,11 +64,13 @@
   <%= @event.external_zip %>
 </p>
 
-<p>
-  <strong>Person:</strong>
-  <%= @event.person.first_name %>
-  <%= @event.person.last_name %>
-</p>
+<% unless @event.space.nil? %>
+  <p>
+    <strong>Person:</strong>
+    <%= @event.person.first_name %>
+    <%= @event.person.last_name %>
+  </p>
+<% end %>
 
 <p>
   <strong>External contact name:</strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,20 @@ en:
         address1: "Street Address"
         address2: "City, State Zip"
   fortytude:
+    default:
+      event:
+        title: "No Title"
+        description: "No Description"
+        external_building: "No Building Given"
+        external_space: "No Room Given"
+        external_address: "No Address Given"
+        external_city: "Philadelphia"
+        external_state: "PA"
+        external_zip: "19122"
+        external_contact_name: "No Contact Given"
+        external_contact_email: "No Contact Email Given"
+        external_contact_phone: "No Contact Phone Number"
+        registration_status: "No Registration Required"
     error:
       user_not_registered: "User not registered."
       access_denied: "Account modification - Access denied"

--- a/lib/tasks/events_sync.rake
+++ b/lib/tasks/events_sync.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :events do
+  desc "sync events"
+  task sync: :environment do
+    sync_events = SyncEvents.new(events_url: "https://events.temple.edu/feed/xml/events?department=2566")
+    events = sync_events.read_events
+    sync_events.sync
+  end
+end

--- a/spec/fixtures/files/events.xml
+++ b/spec/fixtures/files/events.xml
@@ -1,0 +1,1721 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Events>
+  <Event>
+    <Title>Data Transparency: Policies and Best Practices</Title>
+    <Path>https://events.temple.edu/data-transparency-policies-and-best-practices</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of Data Transparency: Policies and Best Practices, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;Patrick Woods of the University of Michigan's Office of Research and Sponsored Projects will examine policies impacting data transparency and sharing, as well as data sharing best practices.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Register at &lt;/strong&gt; &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4627492&amp;source=gmail&amp;ust=1537450183920000&amp;usg=AFQjCNGkoE9BVNHpkMriNKS29m4YkspMZQ" href="https://paleystudy.temple.edu/event/4627492" target="_blank"&gt;https://paleystudy.temple.edu/event/4627492&lt;/a&gt; &lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 02, 2018</EventStartDate>
+    <EventStartTime>12:45 pm</EventStartTime>
+    <EventEndDate>October 02, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;02/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538498700</TimestampStart>
+    <TimestampEnd>1538503200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Gladfelter Hall</Location>
+    <Room>Room 914</Room>
+    <Address>1115 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square_0.jpg?itok=QnZs4kB2&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="data powered by you October 1-5, 2018" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45321</GUID>
+  </Event>
+  <Event>
+    <Title>Learning Good Data Habits at the ICPSR Summer Program</Title>
+    <Path>https://events.temple.edu/learning-good-data-habits-at-the-icpsr-summer-program</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of Learning Good Data Habits at the ICPSR Summer Program, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;Summer Program courses allow participants to leave the program with the right tools and mindsets to explore intricate and complex research questions, and responsibly share their finds in way that could change community attitudes or even alter public policy. Presented by Sandy Schneider, Director of the ICPSR Summer Program.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Register at&lt;/strong&gt;  &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4628069&amp;source=gmail&amp;ust=1537450183920000&amp;usg=AFQjCNFlrmpIG6NYW1frLCBu2UPIfmO1NQ" href="https://paleystudy.temple.edu/event/4628069" target="_blank"&gt;https://paleystudy.temple.edu/event/4628069&lt;/a&gt; &lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 03, 2018</EventStartDate>
+    <EventStartTime>1:45 pm</EventStartTime>
+    <EventEndDate>October 03, 2018</EventEndDate>
+    <EventEndTime>3:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;03/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-03T13:45:00-04:00"&gt;13:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-03T15:00:00-04:00"&gt;15:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538588700</TimestampStart>
+    <TimestampEnd>1538593200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Anderson Hall</Location>
+    <Room>Room 1221</Room>
+    <Address>1835 N. 12th Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square_1.jpg?itok=7w4HQd_U&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="Data powered by you October 1-5, 2018" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45331</GUID>
+  </Event>
+  <Event>
+    <Title>Building the 21st Century Library: Transformation of a Campus</Title>
+    <Path>https://events.temple.edu/building-the-21st-century-library-transformation-of-a-campus</Path>
+    <Description>&lt;p&gt;The &lt;em&gt;Building the 21st Century Library&lt;/em&gt; symposium series brings to light the design process for our new &lt;a href="https://library.temple.edu/newlibrary"&gt;Charles Library&lt;/a&gt; and gives the Temple community a chance to engage in dialogue with the planners, designers, and experts as the design and building processes are taking place.&lt;/p&gt;
+
+&lt;p dir="ltr"&gt;This session will explore Charles Library’s potential to transform Temple University’s main campus, from the building’s impact to the relationship between the university and its neighbors to the university’s vision of sustainability. We will also consider what steps have been—or could be—taken to make the building more accessible to the campus and surrounding communities and what opportunities the new building presents to project Temple’s identity and values.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;The conversation will be moderated by &lt;strong&gt;Kevin Delaney&lt;/strong&gt;, vice provost, Faculty Affairs, Temple University. Panelists include:&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Karen Blanchard&lt;/strong&gt;, president, American Institute of Architects Philadelphia Chapter&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Dozie Ibeh&lt;/strong&gt;, associate vice president, Project Delivery Group, Temple University&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Anne Krakow&lt;/strong&gt;, director, Post Learning Commons and Drexel Library, Saint Joseph's University&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Siobhan Reardon&lt;/strong&gt;, president and director, the Free Library of Philadelphia&lt;/p&gt;
+&lt;p dir="ltr"&gt; &lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Photo: Graduate Study in Charles Library, rendering courtesy Snøhetta and Methanoia.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;a href="https://www.eventbrite.com/e/building-the-21st-century-library-transformation-of-a-campus-tickets-49959362799"&gt;Registration&lt;/a&gt; is encouraged.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Community</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 10, 2018</EventStartDate>
+    <EventStartTime>2:00 pm</EventStartTime>
+    <EventEndDate>October 10, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-10T14:00:00-04:00"&gt;10/10/2018 14:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539194400</TimestampStart>
+    <TimestampEnd>1539194400</TimestampEnd>
+    <Tags>Building the 21st Century Library</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Architecture Building</Location>
+    <Room>Room 104</Room>
+    <Address>2001 N. 13th Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Graduate%20Scholars.jpg?itok=kFC_Flgx&amp;c=fbb57aa3c4e9af336f886e0101c53a26" alt="rendering of top floor graduate scholars studio" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>44741</GUID>
+  </Event>
+  <Event>
+    <Title>The Cost of Being a Girl: Author Yasemin Besen-Cassino on the Gender Pay Gap</Title>
+    <Path>https://events.temple.edu/the-cost-of-being-a-girl-author-yasemin-besen-cassino-on-the-gender-pay-gap</Path>
+    <Description>&lt;p&gt;Join us for an author talk with &lt;a href="https://www.montclair.edu/profilepages/view_profile.php?username=beseny"&gt;Yasemin Besen-Cassino&lt;/a&gt;, whose latest book, &lt;a href="http://tupress.temple.edu/book/20000000009167"&gt;&lt;em&gt;The Cost of Being a Girl&lt;/em&gt;&lt;/a&gt; (Temple University Press, 2018), focuses on how early work experiences lead to later gender inequalities in the market. This research, supported by the W.E. Upjohn Institute, explores the inequalities in the youth labor force with an intersectional perspective and traces the origins of the wage gap to part-time teenage work. It has been praised by &lt;em&gt;Publishers Weekly&lt;/em&gt; and &lt;em&gt;London School of Economics Review&lt;/em&gt; and was featured in &lt;em&gt;the Washington Post&lt;/em&gt;, &lt;em&gt;the Guardian&lt;/em&gt;, MTV, CNN, and &lt;em&gt;the Philadelphia Inquirer&lt;/em&gt;, among many others.&lt;/p&gt;
+&lt;p&gt;Yasemin Besen-Cassino is a Professor of Sociology at Montclair State University. She served as the Book Review Editor of &lt;em&gt;Gender &amp; Society&lt;/em&gt; (2014-2018) and the Managing Editor of &lt;em&gt;Men &amp; Masculinities&lt;/em&gt; (2003-2005). She received her Ph.D. in Sociology from State University of New York in Stony Brook in 2005. Her research focuses on work, gender, and youth and has appeared in many sociology journals such as &lt;em&gt;Contexts&lt;/em&gt;, &lt;em&gt;Journal of Contemporary Ethnography&lt;/em&gt;, &lt;em&gt;Theory &amp; Society&lt;/em&gt;, &lt;em&gt;NWSAJ&lt;/em&gt;, and &lt;em&gt;Education &amp; Society&lt;/em&gt;. In addition, her work has been featured in many popular venues such as &lt;em&gt;the Washington Post&lt;/em&gt;, &lt;em&gt;the Guardian&lt;/em&gt;, &lt;em&gt;The Atlantic&lt;/em&gt;, CNN, MTV, &lt;em&gt;Fortune&lt;/em&gt;, and &lt;em&gt;Ms. Magazine&lt;/em&gt;, and many others.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.eventbrite.com/e/the-cost-of-being-a-girl-author-yasemin-besen-cassino-on-the-gender-pay-gap-tickets-48657944221"&gt;Registration&lt;/a&gt; is requested.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Community</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 15, 2018</EventStartDate>
+    <EventStartTime>2:00 pm</EventStartTime>
+    <EventEndDate>October 15, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-15T14:00:00-04:00"&gt;15/10/2018 14:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539626400</TimestampStart>
+    <TimestampEnd>1539626400</TimestampEnd>
+    <Tags>Access and Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Cost%20of%20Being%20A%20Girl_sq.jpg?itok=dr7P-G9P&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="cost of being a girl" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>41746</GUID>
+  </Event>
+  <Event>
+    <Title>Students, Labor Activism, and Publishing: From Radical America to Jacobin</Title>
+    <Path>https://events.temple.edu/students-labor-activism-and-publishing-from-radical-america-to-jacobin</Path>
+    <Description>&lt;p&gt; &lt;/p&gt;
+
+&lt;p&gt;In the late 1960s, a group of graduate students affiliated with Students for a Democratic Society (SDS) established a journal called &lt;em&gt;Radical America&lt;/em&gt;. The journal uncovered the historical roots of present-day issues facing working-class men and women, challenged the idea that students did not care about unions, and celebrated the vibrant (but often hidden) currents of radical multiracial and multicultural movements. In 2011, twelve years after &lt;em&gt;Radical America&lt;/em&gt; ceased publication, the magazine &lt;a href="https://www.jacobinmag.com/"&gt;&lt;em&gt;Jacobin&lt;/em&gt;&lt;/a&gt; was founded. Started by an undergraduate student, it has grown to become one of the leading voices of the American left, publishing the work of radical journalists, academics, and artists, and championing movements for social justice.&lt;/p&gt;
+&lt;p&gt;Please join us for a conversation with &lt;em&gt;Jacobin&lt;/em&gt; founding editor Bhaskar Sunkara and former &lt;em&gt;Radical America&lt;/em&gt; editor Allen Hunter about the role of students and labor activism in 2018. What can today’s students learn from students of the 1960s? How can labor and other social movements involve students and be responsive to their ideas, needs, and aspirations? And how can magazines, blogs, and other publications help students amplify their voices?&lt;/p&gt;
+&lt;p&gt;Moderated by Minju Bae, a PhD Candidate in the History Department at Temple University.&lt;/p&gt;
+&lt;p&gt;&lt;em&gt;&lt;a href="http://tupress.temple.edu/open-access/labor-studies/6"&gt;Workers’ Struggles, Past and Present: A “Radical America” Reader&lt;/a&gt;, edited by James Green, was reissued by Temple University Press in 2018 and is now freely available to read online. It is part of a larger collection of open access books on &lt;a href="http://tupress.temple.edu/open-access/labor-studies"&gt;Labor Studies and Work&lt;/a&gt; published by Temple University Press. &lt;/em&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;&lt;em&gt;This event has been made possible in part by the National Endowment for the Humanities: Exploring the human endeavor.&lt;/em&gt;&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.eventbrite.com/e/students-labor-activism-and-publishing-from-radical-america-to-jacobin-tickets-50067738955"&gt;Registration&lt;/a&gt; is encouraged.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Community</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 17, 2018</EventStartDate>
+    <EventStartTime>6:00 pm</EventStartTime>
+    <EventEndDate>October 17, 2018</EventEndDate>
+    <EventEndTime>6:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-17T18:00:00-04:00"&gt;17/10/2018 18:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539813600</TimestampStart>
+    <TimestampEnd>1539813600</TimestampEnd>
+    <Tags>Access &amp; Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Students%20Labor%20Activism.jpg?itok=7juXKID6&amp;c=b39c193ce4e8366460ce99fbf809e199" alt="Radical America book cover" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>44846</GUID>
+  </Event>
+  <Event>
+    <Title>Refugees &amp; Resettlement: The Hebrew Immigrant Aid Society in the Vietnam War Era and Beyond</Title>
+    <Path>https://events.temple.edu/refugees-resettlement-the-hebrew-immigrant-aid-society-in-the-vietnam-war-era-and-beyond-0</Path>
+    <Description>&lt;p&gt;Temple University archivist Jessica Lydon will discuss the collection from HIAS (Hebrew Immigrant Aid Society) Pennsylvania, housed in the &lt;a href="https://library.temple.edu/scrc"&gt;Special Collections Research Center&lt;/a&gt;. The collection highlights the organization's history resettling Jewish refugees in the late 19th and early 20th centuries and, also, includes materials about HIAS's efforts to assist refugees from the Vietnam War. Professor Dieu Nguyen, an historian of Vietnam and migration, and Cathryn Miller-Wilson, the Executive Director of &lt;a href="http://www.hiaspa.org/"&gt;HIAS Pennsylvania&lt;/a&gt;, will join Lydon for a panel discussion moderated by Professor Lila Corwin Berman about HIAS's history, its various resettlement efforts, and the work HIAS is doing to address today's refugee crisis.&lt;/p&gt;
+&lt;p&gt;	Free and open to the public.&lt;/p&gt;
+&lt;p&gt;
+	&lt;em&gt;Sponsored by the Feinstein Center for American Jewish History.&lt;/em&gt;&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>History</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 25, 2018</EventStartDate>
+    <EventStartTime>9:30 am</EventStartTime>
+    <EventEndDate>October 25, 2018</EventEndDate>
+    <EventEndTime>9:30 am</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-25T09:30:00-04:00"&gt;25/10/2018 09:30&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540474200</TimestampStart>
+    <TimestampEnd>1540474200</TimestampEnd>
+    <Tags>Special Collections Research Center</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Ariella Werden-Greenfield</ContactName>
+    <ContactEmail>ariella.werden@temple.edu</ContactEmail>
+    <ContactPhone>914-907-2893</ContactPhone>
+    <Image></Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45301</GUID>
+  </Event>
+  <Event>
+    <Title>1968 Kerner Commission: What Can We Learn 50 Years Later? Steve Gillon and Alan Curtis in Conversation with Karen M. Turner</Title>
+    <Path>https://events.temple.edu/1968-kerner-commission-what-can-we-learn-50-years-later-steve-gillon-and-alan-curtis-in-conversation</Path>
+    <Description>&lt;p&gt;1968 was a year that changed our world. The year brought us both the King and Kennedy assassinations and the opening Off-Broadway of "The Boys in the Band," the groundbreaking play featuring gay characters. Women’s liberation groups protested the Miss America contest and Tommie Smith and John Carlos clenched their fists in a black power salute at the Mexico City Summer Olympic Games. New York democrat Shirley Chisholm was elected as the first Black female U.S. Representative and students protested at Columbia University, in Mexico City, and around Europe. Locally, four Black boys entered Girard College after a 14-year desegregation battle and Progress Plaza was dedicated as an example of positive urban renewal and investment.&lt;/p&gt;
+&lt;p&gt;In 1968, the Kerner Commission warned racism was causing America to move “toward two societies, one black, one white—separate and unequal.” Join us for a conversation celebrating and reflecting on 1968 and the legacy of the Kerner Commission with Steven M. Gillon, author of &lt;a href="https://www.amazon.com/dp/B073P43LWL"&gt;&lt;em&gt;Separate and Unequal: The Kerner Commission and the Unraveling of American Liberalism&lt;/em&gt;&lt;/a&gt; and Alan Curtis, co-editor of&lt;a href="http://tupress.temple.edu/book/20000000009771"&gt;&lt;em&gt; Healing our Divided Society: Investing in America Fifty Years after the Kerner Report&lt;/em&gt;&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;	&lt;a href="https://www.eventbrite.com/e/1968-kerner-commission-what-can-we-learn-50-years-later-tickets-48658194971"&gt;Registration&lt;/a&gt; is encouraged.&lt;/p&gt;
+&lt;p&gt;&lt;em&gt;This program is co-sponsored by the Klein College of Media and Communication and the Academic Center on Research in Diversity (ACCORD).&lt;/em&gt;&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Community</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 30, 2018</EventStartDate>
+    <EventStartTime>3:30 pm</EventStartTime>
+    <EventEndDate>October 30, 2018</EventEndDate>
+    <EventEndTime>3:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-30T15:30:00-04:00"&gt;30/10/2018 15:30&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540927800</TimestampStart>
+    <TimestampEnd>1540927800</TimestampEnd>
+    <Tags>Access and Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/kerner%20commission.jpg?itok=MJlXzqy4&amp;c=e9c1b66bf2ce9a4f517e3c5fc98c1fd2" alt="kerner commission" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>41751</GUID>
+  </Event>
+  <Event>
+    <Title>The Working People of Philadelphia, Then and Now</Title>
+    <Path>https://events.temple.edu/the-working-people-of-philadelphia-then-and-now</Path>
+    <Description>&lt;p&gt;In 1980, historian Bruce Laurie published &lt;a href="http://tupress.temple.edu/open-access/epub/7/Laurie_9781439917947.epub#epubcfi(/6/2[nav_00]!/4/1:0)" rel="noopener noreferrer nofollow" target="_blank"&gt;&lt;em&gt;The Working People of Philadelphia,&lt;/em&gt; &lt;em&gt;1800-1850&lt;/em&gt;&lt;/a&gt;. The book has now been reissued in a freely available online format by Temple University Press. In celebration of its return, please join us for a conversation with historians and Philadelphia natives Francis Ryan and Sharon McConnell-Siddorick. They will discuss questions such as: what was it like to be a worker in Philadelphia in the nineteenth century? How was the Philadelphia working class constituted by race, ethnicity, gender, and occupation? What were some of the major problems, hopes, and aspirations that workers shared? What were the cultures, organizations, and institutions that workers created? In what ways have things changed for the better for Philadelphia workers in 2018, and in what ways are they still struggling?&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+
+&lt;p dir="ltr"&gt;Speakers:&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Francis Ryan&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Sharon McConnell-Sidorick&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Moderator:&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Cynthia Little&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt; &lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;em&gt;&lt;a href="http://tupress.temple.edu/open-access/labor-studies/7"&gt;Working People of Philadelphia, 1800-1850&lt;/a&gt;, by Bruce Laurie, was reissued by Temple University Press in 2018 and is now freely available online. It is part of a larger collection of open access books on&lt;a href="http://tupress.temple.edu/open-access/labor-studies"&gt; Labor Studies and Work&lt;/a&gt; published by Temple University Press.&lt;/em&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;em&gt;&lt;strong&gt;This event has been made possible in part by the National Endowment for the Humanities: Exploring the human endeavor.&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Image credit:&lt;/p&gt;
+&lt;p dir="ltr"&gt;Photograph of workers etching labels onto saws at Disston Saw, Tool and File Works, Philadelphia, Pennsylvania, circa 1920s. United Saw, Files, and Steel Product Workers of America Records, Special Collections Research Center, Temple University Libraries.&lt;/p&gt;
+&lt;p dir="ltr"&gt;Registration is requested &lt;a href="https://www.eventbrite.com/e/the-working-people-of-philadelphia-then-and-now-tickets-50361771414 "&gt;https://www.eventbrite.com/e/the-working-people-of-philadelphia-then-and...&lt;/a&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt; &lt;/p&gt;
+&lt;p dir="ltr"&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>History</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>November 07, 2018</EventStartDate>
+    <EventStartTime>6:00 pm</EventStartTime>
+    <EventEndDate>November 07, 2018</EventEndDate>
+    <EventEndTime>6:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-11-07T18:00:00-05:00"&gt;07/11/2018 18:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1541631600</TimestampStart>
+    <TimestampEnd>1541631600</TimestampEnd>
+    <Tags>Access &amp; Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus></Campus>
+    <Location>Ethical Society</Location>
+    <Room></Room>
+    <Address>1906 Rittenhouse Square</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19103</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Annie Johnson</ContactName>
+    <ContactEmail>annie.johnson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-6511</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/working%20people%20of%20philadelphia.jpg?itok=9N96JOn2&amp;c=fba5ef7eaf0b5225f1b749cb53e70942" alt="Photograph of workers etching labels onto saws at Disston Saw, Tool and File Works, Philadelphia, Pennsylvania, circa 1920s. United Saw, Files, and Steel Product Workers of America Records, Special Collections Research Center, Temple University Libraries." /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45316</GUID>
+  </Event>
+  <Event>
+    <Title>Extended - Food For Fines</Title>
+    <Path>https://events.temple.edu/extended-food-for-fines</Path>
+    <Description>&lt;p&gt;Join Temple University Libraries as we team up with &lt;a href="https://studentaffairs.temple.edu/cherry-pantry"&gt;Cherry Pantry&lt;/a&gt;, the Temple community’s food pantry, to host the Food for Fines food drive and fee forgiveness program. We are accepting food donations at our &lt;em&gt;Beyond the Page&lt;/em&gt; &lt;a href="https://library.temple.edu/beyondthepage/event/kickoff-program-sara-goldrick"&gt;kickoff program&lt;/a&gt; on September 11, where Temple Professor and nationally recognized scholar Sara Goldrick-Rab will discuss access and opportunity in higher education.&lt;/p&gt;
+
+&lt;p dir="ltr"&gt;Our fee forgiveness program starts September 12 and goes through October 5. Stop by Paley Library’s circulation desk and we will waive $2 in library late fees for each approved food item you donate.&lt;/p&gt;
+&lt;p dir="ltr"&gt;All items must be non-perishable and unopened. Suggestions include canned fish, canned poultry, canned fruit, cereal, oatmeal, peanut butter, jelly, pasta, rice, pasta sauce, granola bars, and juice.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Community</Interest>
+    <Type>Volunteer Opportunity</Type>
+    <EventStartDate>September 12, 2018</EventStartDate>
+    <EventStartTime>(All day)</EventStartTime>
+    <EventEndDate>October 05, 2018</EventEndDate>
+    <EventEndTime>(All day)</EventEndTime>
+    <Timestamp>&lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-09-12T00:00:00-04:00"&gt;12/09/2018 (All day)&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-05T00:00:00-04:00"&gt;05/10/2018 (All day)&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1536724800</TimestampStart>
+    <TimestampEnd>1538712000</TimestampEnd>
+    <Tags>Access &amp; Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room></Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/food_for_fines_highlight.jpg?itok=AG9GCRYY&amp;c=e92e75771d698705a92487975f5feb3b" alt="can of mushrooms" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44486</GUID>
+  </Event>
+  <Event>
+    <Title>Introducing the United States Census Bureau Data Repository</Title>
+    <Path>https://events.temple.edu/introducing-the-united-states-census-bureau-data-repository</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of Metadata to interpret our statistics into the future: Introducing the United States Census Bureau Data Repository, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;A new US Census Bureau Data Repository has been launched to preserve and disseminate survey instruments, specifications, data dictionaries, codebooks, and other materials provided by the Census Bureau. The repository also lists additional Census-related data collections from ICPSR's larger holdings. This repository helps fulfill key recommendations made by the 2017 “Report of the Commission on Evidence-Based Policymaking” and it continues the long-standing partnership between the US Census Bureau and ICPSR, dating back to the 1960s. Presented by Jared Lyle, Director of Metadata and Preservation at ICPSR and Director of the Data Documentation Initiative (DDI) Alliance.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4627995&amp;source=gmail&amp;ust=1537450183920000&amp;usg=AFQjCNG42fjjq3RMbjjNNAvpeKbeK-XzRA" href="https://paleystudy.temple.edu/event/4627995" target="_blank"&gt;https://paleystudy.temple.edu/event/4627995&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 02, 2018</EventStartDate>
+    <EventStartTime>2:45 pm</EventStartTime>
+    <EventEndDate>October 02, 2018</EventEndDate>
+    <EventEndTime>4:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;02/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T14:45:00-04:00"&gt;14:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T16:00:00-04:00"&gt;16:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538505900</TimestampStart>
+    <TimestampEnd>1538510400</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square.jpg?itok=1sOM2qFw&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="Data Powered By You October 1-5, 2018" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>45346</GUID>
+  </Event>
+  <Event>
+    <Title>Calling Bullsh*t in an Era of Misinformation: Developing a Fact-Checking Mindset</Title>
+    <Path>https://events.temple.edu/calling-bullsht-in-an-era-of-misinformation-developing-a-fact-checking-mindset-0</Path>
+    <Description>&lt;p&gt;Discerning fact from fiction can be hard. Join us to gain strategies and tools for fact-checking news stories based on methods the pros use so that you too can be a savvy consumer of everyday information. Bring your laptop or borrow one from the Digital Scholarship Center. Part of the Libraries' 'Calling Bullsh*t in an Era of Misinformation' workshop series.&lt;/p&gt;
+&lt;p&gt;Please register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4492110&amp;source=gmail&amp;ust=1534523192675000&amp;usg=AFQjCNGnX1h8nlaCSAxhz_35vesW7eSrxw" href="https://paleystudy.temple.edu/event/4492110" target="_blank"&gt;https://paleystudy.temple.edu/event/4492110&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 03, 2018</EventStartDate>
+    <EventStartTime>1:00 pm</EventStartTime>
+    <EventEndDate>October 03, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;03/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-03T13:00:00-04:00"&gt;13:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-03T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538586000</TimestampStart>
+    <TimestampEnd>1538589600</TimestampEnd>
+    <Tags>Library Workshop</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Bull_banner%20larger_4.jpg?itok=TjCG_f4n&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="bull and words calling bullsh*t" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42646</GUID>
+  </Event>
+  <Event>
+    <Title>Philly Public Arts Forum: Building the #TempleFreewall</Title>
+    <Path>https://events.temple.edu/philly-public-arts-forum-building-the-templefreewall</Path>
+    <Description>&lt;p dir="ltr"&gt;Join Philly street artist Blur and poet and organizer Luis Marrero (of Voices of Power) to get some tips on writing, creating, and wheatpasting your own art (supplies will be available). We'll be pasting up all the work on our freewall together at the end of the workshop.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;In this series of events, we’ll explore the state of art in Philadelphia’s public spaces. Who’s creating the work we see around the city? How does access to art and arts education shape who’s invited to participate in our city’s creative placemaking? And what role can public art play in sparking conversation, empowerment, empathy, and understanding around important social and political issues?&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;About the Organizers:&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Cindy M. Ngo&lt;/strong&gt; is currently the promotions manager at Social Impact Studios, the co-founder of &lt;em&gt;Eat Up The Borders&lt;/em&gt;, and a lifelong Philadelphian. Her latest project will take her across the country as a creative collaborator to share the stories for the 2018-19 Intercultural Leadership Institute cohort of fellows, an intensive leadership development program that brings together rising artists and culture bearers from marginalized communities across the United States.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;Conrad Benner&lt;/strong&gt; is a photographer, podcaster, curator, and founder of &lt;a href="http://streetsdept.com/"&gt;StreetsDept.com&lt;/a&gt;, a photo-blog that discovers art on the streets of Philadelphia. Conrad’s blog has been named one of the ‘Best Blogs for Travellers’ by The Guardian, and his photography has been highlighted by Mashable and Instagram, as well as printed in Time Magazine and the Encyclopedia Britannica.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.eventbrite.com/e/philly-public-arts-forum-wheatpaste-workshop-tickets-48660598159"&gt;Registration&lt;/a&gt; is encouraged.&lt;/p&gt;
+&lt;p&gt;Public art by Blur, photo courtesy Conrad Benner.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Lecture, Workshop /  Webinar</Type>
+    <EventStartDate>October 03, 2018</EventStartDate>
+    <EventStartTime>6:00 pm</EventStartTime>
+    <EventEndDate>October 03, 2018</EventEndDate>
+    <EventEndTime>6:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-03T18:00:00-04:00"&gt;03/10/2018 18:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538604000</TimestampStart>
+    <TimestampEnd>1538604000</TimestampEnd>
+    <Tags>Access and Opportunity</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/wheatpaste%20workshop.jpg?itok=hgNSymTK&amp;c=5f745f9c0b0b98d3738c9dcd72bd446f" alt="image of a mouth open that says in a world where women are told to take up less space I refuse to shrink" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>41766</GUID>
+  </Event>
+  <Event>
+    <Title>&quot;I&#039;ve got these data, where do I put them?&quot;: A Look at Deposit Options at ICPSR</Title>
+    <Path>https://events.temple.edu/ive-got-these-data-where-do-i-put-them-a-look-at-deposit-options-at-icpsr</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of "I've got these data, where do I put them?": A Look at Deposit Options at ICPSR, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;A look at all of your options for depositing data with ICPSR from self deposit through full curation. A walk-through of the deposit process will be included. Presented by: Lynette Hoelter, Director of Instructional Resources at ICPSR.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Register at&lt;/strong&gt; &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4627923&amp;source=gmail&amp;ust=1537450183920000&amp;usg=AFQjCNGuXG_TwfMLu_USGHXYzBoIPVjytw" href="https://paleystudy.temple.edu/event/4627923" target="_blank"&gt;https://paleystudy.temple.edu/event/4627923&lt;/a&gt; &lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 04, 2018</EventStartDate>
+    <EventStartTime>12:45 pm</EventStartTime>
+    <EventEndDate>October 04, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;04/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-04T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-04T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538671500</TimestampStart>
+    <TimestampEnd>1538676000</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square_2.jpg?itok=-RGSgiFA&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="Data powered by you" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>45336</GUID>
+  </Event>
+  <Event>
+    <Title>From Asking Questions to Sharing Data: A Look at Ethics in Social Research</Title>
+    <Path>https://events.temple.edu/from-asking-questions-to-sharing-data-a-look-at-ethics-in-social-research</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of From Asking Questions to Sharing Data: A Look at Ethics in Social Research, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;The attention on data sharing has focused ethics discussions on the informed consent process, but collecting, sharing, and reusing data actually involve a series of potential ethical considerations. This session will focus on the ways in which decisions about sampling, question wording, and even analyzing data can have ethical implications. Presented by Lynette Hoelter, Director of Instructional Resources at ICPSR.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Register at&lt;/strong&gt; &lt;a href="https://paleystudy.temple.edu/event/4627993 "&gt;https://paleystudy.temple.edu/event/4627993 &lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 05, 2018</EventStartDate>
+    <EventStartTime>12:45 pm</EventStartTime>
+    <EventEndDate>October 05, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;05/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-05T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-05T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538757900</TimestampStart>
+    <TimestampEnd>1538762400</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square_3.jpg?itok=WMXkrM-9&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="Data Powered By You October 1-5, 2018" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>45341</GUID>
+  </Event>
+  <Event>
+    <Title>Midday Arts Series: An Afternoon with Ryan Eckes and Meg Lemieur</Title>
+    <Path>https://events.temple.edu/midday-arts-series-an-afternoon-with-ryan-eckes-and-meg-lemieur</Path>
+    <Description>&lt;p&gt;Join us for an afternoon of poetry and art, with Ryan Eckes and Meg Lemieur.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;strong&gt;&lt;a href="http://ryaneckes.blogspot.com/"&gt;Ryan Eckes&lt;/a&gt; &lt;/strong&gt;is a poet from Philadelphia. His latest book, &lt;em&gt;General Motors&lt;/em&gt; (Split Lip Press, 2018), is about labor and the influence of public and private transportation on city life. Other books include &lt;em&gt;Valu-Plus&lt;/em&gt; and &lt;em&gt;Old News&lt;/em&gt; (Furniture Press 2014, 2011). His poetry can be found in &lt;em&gt;Tripwire&lt;/em&gt;, &lt;em&gt;Slow Poetry in America Newsletter&lt;/em&gt;, &lt;em&gt;Entropy&lt;/em&gt; and elsewhere. In recent years, he has worked as an adjunct professor and labor organizer in education. He won a Pew Fellowship in 2016.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;a href="https://www.meglemieur.com/"&gt;&lt;strong&gt;Meg Lemieur’s&lt;/strong&gt;&lt;/a&gt; art juxtaposes nature with the human experience while exploring the themes of social and environmental justice with a hopeful perspective and questioning sensibility. She, along with Bri Barton, is a co-founder of the Water Ways project, a collaboratively-drawn series of highly detailed pen and ink illustrations telling the story of water and the effects that the natural gas industry has on the area commonly known as Pennsylvania and New Jersey. Each illustration consists of dozens of small vignettes that highlight people’s struggles as they strive to protect the water and land on which we all survive.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://www.eventbrite.com/e/midday-arts-series-an-afternoon-with-ryan-eckes-and-meg-lemieur-tickets-50493700016"&gt;Registration&lt;/a&gt; requested.&lt;/p&gt;
+&lt;p&gt;Photo courtesy Brae Howard.&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Lecture, Performance</Type>
+    <EventStartDate>October 09, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>October 09, 2018</EventEndDate>
+    <EventEndTime>12:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-09T12:30:00-04:00"&gt;09/10/2018 12:30&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539102600</TimestampStart>
+    <TimestampEnd>1539102600</TimestampEnd>
+    <Tags>Partnership Programs</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Midday%20Arts.jpg?itok=C0F8av-s&amp;c=7a65b1133c062da3486fe0c391f418ea" alt="audience shot" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>45456</GUID>
+  </Event>
+  <Event>
+    <Title>Calling Bullsh*t in an Era of Misinformation: Detecting Misleading Data</Title>
+    <Path>https://events.temple.edu/calling-bullsht-in-an-era-of-misinformation-detecting-misleading-data-0</Path>
+    <Description>&lt;p&gt;We live in a world of big data. Get tips on making sense of the charts, graphs, tables, polls, and statistics that appear in the news, journals, books and websites that you read, and view their validity with a critical eye. Bring your laptop or borrow one from the Digital Scholarship Center. Part of the Libraries' 'Calling Bullsh*t in an Era of Misinformation' workshop series.&lt;/p&gt;
+&lt;p&gt;Please register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4492134&amp;source=gmail&amp;ust=1534523192675000&amp;usg=AFQjCNFcdwgF-VoDPHApg96vTsH_Mcktdw" href="https://paleystudy.temple.edu/event/4492134" target="_blank"&gt;https://paleystudy.temple.edu/event/4492134&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 10, 2018</EventStartDate>
+    <EventStartTime>1:00 pm</EventStartTime>
+    <EventEndDate>October 10, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;10/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-10T13:00:00-04:00"&gt;13:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-10T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539190800</TimestampStart>
+    <TimestampEnd>1539194400</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Bull_banner%20larger_5.jpg?itok=vYEDv8_p&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="bull with the words calling bullsh*t" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42651</GUID>
+  </Event>
+  <Event>
+    <Title>Zinemaking</Title>
+    <Path>https://events.temple.edu/zinemaking</Path>
+    <Description>&lt;p&gt;Makerspaces are not just about robots and virtual reality - critical making can also include low tech objects like small, self-published magazines, known as zines. Come to this hands-on workshop series to make zines using found and original images and text, scissors, staplers, and your favorite adhesives. You'll also get to handle zines from the Libraries’ collections, and learn why zines are still important in 2018. All materials provided, and you're welcome to bring your own. &lt;/p&gt;
+&lt;p&gt;There will be four workshops in this series. You are not required to come to every one, but each workshop will build on the last, so consistent attendance is encouraged.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4503551&amp;source=gmail&amp;ust=1534850703582000&amp;usg=AFQjCNF3DQQ4Mcg8TbMzY6lX_mbJBhrVeA" href="https://paleystudy.temple.edu/event/4503551" target="_blank"&gt;https://paleystudy.temple.edu/event/4503551&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 10, 2018</EventStartDate>
+    <EventStartTime>3:00 pm</EventStartTime>
+    <EventEndDate>October 10, 2018</EventEndDate>
+    <EventEndTime>4:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;10/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-10T15:00:00-04:00"&gt;15:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-10T16:00:00-04:00"&gt;16:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539198000</TimestampStart>
+    <TimestampEnd>1539201600</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Caitlin Shanley</ContactName>
+    <ContactEmail>cshanley@temple.edu</ContactEmail>
+    <ContactPhone>215-204-3187</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/zineworkshoplogo_0.jpg?itok=tJwDEu6X&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="zinemaking" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42746</GUID>
+  </Event>
+  <Event>
+    <Title>Chat in the Stacks: Remembering 1968</Title>
+    <Path>https://events.temple.edu/chat-in-the-stacks-remembering-1968</Path>
+    <Description>&lt;p&gt; &lt;/p&gt;
+
+&lt;p dir="ltr"&gt;For eleven years running, the Libraries and the Faculty Senate Committee on the Status of Faculty of Color have co-hosted this engaging series of panels on timely topics, featuring faculty from across the university.&lt;/p&gt;
+&lt;p dir="ltr"&gt;Join us for our first Chat in the Stacks of the fall semester during which we’ll look back at the pivotal year of 1968 and consider how it continues to inform our current discussions around identity, politics, and race in America.&lt;/p&gt;
+&lt;p dir="ltr"&gt;&lt;a href="https://www.eventbrite.com/e/chat-in-the-stacks-remembering-1968-tickets-50136616971"&gt;Registration&lt;/a&gt; requested.&lt;/p&gt;
+&lt;p dir="ltr"&gt;For more information on the Libraries' &lt;em&gt;Beyond the Page&lt;/em&gt; public programming series, visit library.temple.edu/beyondthepage.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>History</Interest>
+    <Type>Lecture</Type>
+    <EventStartDate>October 11, 2018</EventStartDate>
+    <EventStartTime>2:30 pm</EventStartTime>
+    <EventEndDate>October 11, 2018</EventEndDate>
+    <EventEndTime>2:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-11T14:30:00-04:00"&gt;11/10/2018 14:30&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539282600</TimestampStart>
+    <TimestampEnd>1539282600</TimestampEnd>
+    <Tags>Chat in the Stacks</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Sara Wilson</ContactName>
+    <ContactEmail>sarawilson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2828</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Chat%20in%20the%20stacks.jpg?itok=VTlu0Awj&amp;c=4089a71ef68966888f1f6d6fee3b1a81" alt="Chat in the stacks" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44966</GUID>
+  </Event>
+  <Event>
+    <Title>Developing Your Scholarly Profile</Title>
+    <Path>https://events.temple.edu/developing-your-scholarly-profile-1</Path>
+    <Description>&lt;p&gt;Join us to explore the professional and ethical uses of academic social networks such as ResearchGate and Academia as well as preferences of scholars in different disciplines. We will talk about ORCiD and other researcher IDs and how they can be used to enhance your online profile. Bring your laptop or borrow one from the Digital Scholarship Center.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4203283&amp;source=gmail&amp;ust=1531997750098000&amp;usg=AFQjCNG0ZmfkJzfqbCIWAdMgZ_J4VHl0ug" href="https://paleystudy.temple.edu/event/4203283" target="_blank"&gt;https://paleystudy.temple.edu/event/4203283&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 16, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>October 16, 2018</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;16/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-16T12:30:00-04:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-16T13:30:00-04:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539707400</TimestampStart>
+    <TimestampEnd>1539711000</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ResearchImpactBanner_Square%20%282%29_1.jpg?itok=9rLIFxyI&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="research impact" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>41491</GUID>
+  </Event>
+  <Event>
+    <Title>How to Write and Publish a Case Report</Title>
+    <Path>https://events.temple.edu/how-to-write-and-publish-a-case-report</Path>
+    <Description>&lt;p&gt;This workshop will provide assistance in writing and publishing a case report. The components and organization of a case study will be reviewed as well as guidelines and approaches for writing a case report. In addition, we will offer strategies for finding and choosing a journal for publication.&lt;/p&gt;
+&lt;p&gt;Please contact Natalie Tagge,&lt;a href="mailto:%20natalie.tagge@temple.edu"&gt; natalie.tagge@temple.edu&lt;/a&gt; with any questions or to RSVP for a group of 15 or more.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a href="https://ginsburgstudy.temple.edu/event/4353369"&gt;https://ginsburgstudy.temple.edu/event/4353369&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 17, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>October 17, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;17/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-17T12:00:00-04:00"&gt;12:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-17T13:00:00-04:00"&gt;13:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539792000</TimestampStart>
+    <TimestampEnd>1539795600</TimestampEnd>
+    <Tags>Health Sciences Libraries</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Health Sciences Center</Campus>
+    <Location>Ginsburg Health Sciences Library</Location>
+    <Room>Computer Lab Room 248</Room>
+    <Address>3500 N Broad St.</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19140</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Natalie Tagge</ContactName>
+    <ContactEmail>natalie.tagge@temple.edu</ContactEmail>
+    <ContactPhone>215-707-4557</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Case%20Report%20HSL.jpg?itok=DZylFgrk&amp;c=066837b3de05af2779ffb88b34b40e22" alt="case report " /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44266</GUID>
+  </Event>
+  <Event>
+    <Title>Calling Bullsh*t in an Era of Misinformation: Refuting Claims Persuasively</Title>
+    <Path>https://events.temple.edu/calling-bullsht-in-an-era-of-misinformation-refuting-claims-persuasively</Path>
+    <Description>&lt;p&gt;Where is the line between providing constructive criticism and being sarcastic or just plain nasty? Join us to discuss the ethics behind calling out misinformation/disinformation and gain strategies for refuting false claims online and in person. Bring your laptop or borrow one from the Digital Scholarship Center. Part of the Libraries' 'Calling Bullsh*t in an Era of Misinformation' workshop series.&lt;/p&gt;
+&lt;p&gt;Please register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4492151&amp;source=gmail&amp;ust=1534523192675000&amp;usg=AFQjCNHPQGmpBW7uZ_W0Sf9sImfyCHqg-Q" href="https://paleystudy.temple.edu/event/4492151" target="_blank"&gt;https://paleystudy.temple.edu/event/4492151&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 17, 2018</EventStartDate>
+    <EventStartTime>1:00 pm</EventStartTime>
+    <EventEndDate>October 17, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;17/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-17T13:00:00-04:00"&gt;13:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-17T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1539795600</TimestampStart>
+    <TimestampEnd>1539799200</TimestampEnd>
+    <Tags>undefined</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/Bull_banner%20larger.jpg?itok=TGoHizR8&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="bull banner" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42656</GUID>
+  </Event>
+  <Event>
+    <Title>Boyer Artist-in-Residence Zach Brock, Jazz Violinist</Title>
+    <Path>https://events.temple.edu/boyer-artist-in-residence-zach-brock-jazz-violinist</Path>
+    <Description>&lt;p&gt;GRAMMY Award winner and Boyer Artist-in-Residence &lt;a href="http://zackbrock.com/"&gt;Zach Brock&lt;/a&gt;, “the pre-eminent improvising violinist of his generation,” evokes the spirit of John Coltrane, Bela Bartok, and Jimi Hendrix. Join us and experience the creativity of this amazing musician.&lt;/p&gt;
+
+&lt;p dir="ltr"&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Light refreshments served. Boyer recital credit given.&lt;/p&gt;
+&lt;p dir="ltr"&gt;This performance is part of Temple University Libraries' &lt;a href="https://sites.temple.edu/performingartsnews/2018/08/20/beyond-the-notes-announces-2018-2019-season/"&gt;Beyond the Notes&lt;/a&gt; Series. It is presented in collaboration with the Center for the Performing and Cinematic Arts. &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Performance</Type>
+    <EventStartDate>October 23, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>October 23, 2018</EventEndDate>
+    <EventEndTime>12:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-10-23T12:00:00-04:00"&gt;23/10/2018 12:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540310400</TimestampStart>
+    <TimestampEnd>1540310400</TimestampEnd>
+    <Tags>Beyond the Notes</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Anne Harlow</ContactName>
+    <ContactEmail>aharlow@temple.edu</ContactEmail>
+    <ContactPhone>215-204-1399</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ZachBrock_Katz_D8C0027a_V1.jpg?itok=3S41FVc7&amp;c=d0eca9ecbef29e2730ce01af379fbdda" alt="Zach Brock" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>43091</GUID>
+  </Event>
+  <Event>
+    <Title>Integrating Open Access Resources into your Canvas Course</Title>
+    <Path>https://events.temple.edu/integrating-open-access-resources-into-your-canvas-course</Path>
+    <Description>&lt;p&gt;Faculty have many choices nowadays when it comes to identifying course materials -- from online textbooks and video content to news articles and PDF files. Some materials are more cost effective than others which can impact student engagement. Canvas invites new ways of thinking about how faculty can integrate a range of course materials as well as draw inspiration from existing learning objects. Join us to learn about tools you can use in Canvas -- such as open educational resources, library-licensed content, Ares course reserves, and the Canvas Commons -- to make it both easy and cost effective for your students to access the materials with which you most want them to engage. Bring your laptop or borrow one from the Digital Scholarship Center. This workshop requires some experience with Canvas.&lt;/p&gt;
+&lt;p&gt;Registration link: &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4485731&amp;source=gmail&amp;ust=1534523192606000&amp;usg=AFQjCNFIKdz-_33rq_irbNfaoGvPspXYWQ" href="https://paleystudy.temple.edu/event/4485731" target="_blank"&gt;https://paleystudy.temple.edu/event/4485731&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Faculty Enrichment</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 23, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>October 23, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;23/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-23T12:30:00-04:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-23T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540312200</TimestampStart>
+    <TimestampEnd>1540317600</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/OA_square300.jpg?itok=yamMe-1b&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="open " /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42661</GUID>
+  </Event>
+  <Event>
+    <Title>Zines and &#039;Za</Title>
+    <Path>https://events.temple.edu/zines-and-za</Path>
+    <Description>&lt;p&gt;Come learn about &lt;a href="https://www.graphicmedicine.org/comic-type/zine/"&gt;Zines&lt;/a&gt; and how to make your own!  Pizza will be served! (Registration is Required)&lt;/p&gt;
+&lt;p&gt;Please &lt;a href="https://ginsburgstudy.temple.edu/event/4418259"&gt;register&lt;/a&gt; by October 22, 2018.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 24, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>October 24, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;24/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T12:00:00-04:00"&gt;12:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T13:00:00-04:00"&gt;13:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540396800</TimestampStart>
+    <TimestampEnd>1540400400</TimestampEnd>
+    <Tags>Health Sciences Libraries, library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Health Sciences Center</Campus>
+    <Location>Ginsburg Health Sciences Library</Location>
+    <Room>Room 243</Room>
+    <Address>3500 N Broad St.</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19140</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Natalie Tagge</ContactName>
+    <ContactEmail>natalie.tagge@temple.edu</ContactEmail>
+    <ContactPhone>215-707-4557</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/zines%20and%20za.jpg?itok=oCqhFzmy&amp;c=3f56cfb05526ebd99ecdd86beab1fe09" alt="slideshow promoting zine and pizza workshop " /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44241</GUID>
+  </Event>
+  <Event>
+    <Title>Introduction to the Open Science Framework</Title>
+    <Path>https://events.temple.edu/introduction-to-the-open-science-framework</Path>
+    <Description>&lt;p&gt;The &lt;a href="https://osf.io/"&gt;Open Science Framework (OSF)&lt;/a&gt; is a free, open source project management tool developed and maintained by the Center for Open Science. The OSF can help scholars manage their workflow, organize their materials, and share all or part of a project with the broader research community. This hands-on workshop will show you how to get started with the OSF. We’ll discuss how to structure your materials, manage permissions, version your content, integrate with third-party tools (such as Box, GitHub, or Mendeley), share materials, register projects, and track usage. No previous experience with OSF is required. Please register for an OSF account with your Temple email address beforehand and bring a laptop.&lt;/p&gt;
+&lt;p&gt;
+	Register at: &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4485912&amp;source=gmail&amp;ust=1534418850086000&amp;usg=AFQjCNEhEPjKCycAFloFkomnmipSiy-yAA" href="https://paleystudy.temple.edu/event/4485912" target="_blank"&gt;https://paleystudy.temple.edu/event/4485912&lt;/a&gt;&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 24, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>October 24, 2018</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;24/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T12:30:00-04:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T13:30:00-04:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540398600</TimestampStart>
+    <TimestampEnd>1540402200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Annie Johnson</ContactName>
+    <ContactEmail>annie.johnson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-6511</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/229101_LOGO_OSF_cycle.jpg?itok=5ojeu0hx&amp;c=8ea2d5302143ce7170a3ff3499df8825" alt="OSF cycle" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42546</GUID>
+  </Event>
+  <Event>
+    <Title>Zinemaking</Title>
+    <Path>https://events.temple.edu/zinemaking-0</Path>
+    <Description>&lt;p&gt;Makerspaces are not just about robots and virtual reality - critical making can also include low tech objects like small, self-published magazines, known as zines. Come to this hands-on workshop series to make zines using found and original images and text, scissors, staplers, and your favorite adhesives. You'll also get to handle zines from the Libraries’ collections, and learn why zines are still important in 2018. All materials provided, and you're welcome to bring your own. &lt;/p&gt;
+&lt;p&gt;There will be four workshops in this series. You are not required to come to every one, but each workshop will build on the last, so consistent attendance is encouraged.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4503551&amp;source=gmail&amp;ust=1534856315980000&amp;usg=AFQjCNGl7_vWku7qOY1f80xgcOhQdmNAmw" href="https://paleystudy.temple.edu/event/4503551" target="_blank"&gt;https://paleystudy.temple.edu/event/4503551&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 24, 2018</EventStartDate>
+    <EventStartTime>3:00 pm</EventStartTime>
+    <EventEndDate>October 24, 2018</EventEndDate>
+    <EventEndTime>4:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;24/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T15:00:00-04:00"&gt;15:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-24T16:00:00-04:00"&gt;16:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540407600</TimestampStart>
+    <TimestampEnd>1540411200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Caitlin Shanley</ContactName>
+    <ContactEmail>cshanley@temple.edu</ContactEmail>
+    <ContactPhone>215-204-3187</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/zineworkshoplogo_1.jpg?itok=7SGKKRVZ&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="zineworkshop logo" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42751</GUID>
+  </Event>
+  <Event>
+    <Title>Using Open Textbooks in the Classroom</Title>
+    <Path>https://events.temple.edu/using-open-textbooks-in-the-classroom-1</Path>
+    <Description>&lt;p dir="ltr"&gt;Did you know that since 1978, the cost of textbooks has increased 810% or 3x the inflation rate? Nationally, students are told to budget $1,200-$1,300 a year for books. That’s a lot of money! One way faculty can make their courses more affordable for students is by assigning an open textbook. Open textbooks are digital books that are free to read, download, and print. In this workshop, we’ll provide an introduction to the world of open educational resources. We’ll discuss how to find high quality open textbooks in your discipline, and show you how these books can be customized to suit the needs of your particular class. In addition, Thomas Wright, Assistant Professor of Instruction and Public Speaking Course Director will share his experience reviewing a book for the Open Textbook Library and his plans to adopt an OER textbook for his course.&lt;/p&gt;
+&lt;p dir="ltr"&gt;Special bonus: The first 10 instructors who register for this workshop and write a brief review of an open textbook that is accepted for publication by the Open Textbook Library will receive a $200 stipend.&lt;/p&gt;
+&lt;p dir="ltr"&gt;
+	Register at: &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4485608&amp;source=gmail&amp;ust=1534418850086000&amp;usg=AFQjCNH0-oBheoS2E-qNINNk8Ual5MUsoA" href="https://paleystudy.temple.edu/event/4485608" target="_blank"&gt;https://paleystudy.temple.edu/event/4485608&lt;/a&gt;&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Faculty Enrichment</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 25, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>October 25, 2018</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;25/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-25T12:30:00-04:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-25T13:30:00-04:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1540485000</TimestampStart>
+    <TimestampEnd>1540488600</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Graduate Students</Audience>
+    <ContactName>Annie Johnson</ContactName>
+    <ContactEmail>annie.johnson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-6511</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/OER%20resized.jpg?itok=YBx6qL0_&amp;c=67b9a7b40e25b95309371fbe96f2ba72" alt="OER" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42551</GUID>
+  </Event>
+  <Event>
+    <Title>Temple University Libraries&#039; Data Grants Program Data</Title>
+    <Path>https://events.temple.edu/temple-university-libraries-data-grants-program-data</Path>
+    <Description>&lt;p&gt;Temple University Libraries is initiating a data grants program and invites all Temple faculty (tenured/tenure track, non-tenure track, adjunct), postdocs, staff, and students (undergraduate and graduate) to submit applications for the purchase of numerical, geospatial, or textual data to support their research or teaching.&lt;/p&gt;
+&lt;p&gt;	Datasets for purchase or by subscription will be considered, though subscriptions will be guaranteed for one year only. Temple Libraries staff assume responsibility for licensing and purchasing of data. Library Data Grants will be made up to $5000.  &lt;/p&gt;
+&lt;p&gt;	&lt;strong&gt;Important dates:&lt;/strong&gt;&lt;br /&gt;
+	Application deadline: November 1, 2018&lt;br /&gt;
+	Announcement of purchases: December 15, 2018&lt;br /&gt;
+	Dataset availability target date: February 15, 2019&lt;/p&gt;
+&lt;p&gt;	&lt;a href="https://library.temple.edu/researchdataservices/library-data-grants"&gt;Learn more&lt;/a&gt; about data criteria, selection criteria, and other requirements.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Deadline</Type>
+    <EventStartDate>November 01, 2018</EventStartDate>
+    <EventStartTime>(All day)</EventStartTime>
+    <EventEndDate>November 01, 2018</EventEndDate>
+    <EventEndTime>(All day)</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-11-01T00:00:00-04:00"&gt;01/11/2018 (All day)&lt;/span&gt;</Timestamp>
+    <TimestampStart>1541044800</TimestampStart>
+    <TimestampEnd>1541044800</TimestampEnd>
+    <Tags></Tags>
+    <PrivateTags></PrivateTags>
+    <Campus></Campus>
+    <Room></Room>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Fred Rowland</ContactName>
+    <ContactEmail>frowland@temple.edu</ContactEmail>
+    <ContactPhone>215-204-3188</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/data%20grants.JPG?itok=q2DQWhJF&amp;c=8ff17a4f5d9308b3ac08ec78ada54368" alt="data grants program" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>43416</GUID>
+  </Event>
+  <Event>
+    <Title>Know Your Copyright: Sharing Your Research</Title>
+    <Path>https://events.temple.edu/know-your-copyright-sharing-your-research</Path>
+    <Description>&lt;p&gt;How do you share your research after it's published? When you sign a publication agreement, what rights are you granting the publisher, and what rights do you retain? Are you allowed to share your own work?&lt;br /&gt;
+	 &lt;br /&gt;
+	In this workshop, participants will gain experience in interpreting publisher’s copyright agreements. We'll review where you can share your works for optimal reach and demystify what publishers mean by “article versions.” Participants will leave with resources to help them share their works to the fullest extent, as well as resources for regaining and retaining sharing rights for past and future publications.&lt;/p&gt;
+&lt;p&gt;	No materials are required for this event, but participants are welcome to bring a copy of a copyright transfer agreement that they've signed, if applicable.&lt;/p&gt;
+&lt;p&gt;	Please register at:&lt;br /&gt;&lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4627170&amp;source=gmail&amp;ust=1537271178661000&amp;usg=AFQjCNHi_iiV6b1MKoFrImTiIbWgeBkneA" href="https://paleystudy.temple.edu/event/4627170" target="_blank"&gt;https://paleystudy.temple.edu/event/4627170&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;	"Copyright" by Nick Youngson is licensed under CC BY-SA 3.0.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>November 06, 2018</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>November 06, 2018</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;06/11/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-11-06T12:30:00-05:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-11-06T13:30:00-05:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1541525400</TimestampStart>
+    <TimestampEnd>1541529000</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Graduate Students</Audience>
+    <ContactName>Annie Johnson</ContactName>
+    <ContactEmail>annie.johnson@temple.edu</ContactEmail>
+    <ContactPhone>215-204-6511</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/copyright.jpg?itok=og05fS4q&amp;c=6dba7b88948980fbbbcf03bfaa1af0ab" alt="copyright" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>45256</GUID>
+  </Event>
+  <Event>
+    <Title>Introduction to Virtual Reality</Title>
+    <Path>https://events.temple.edu/introduction-to-virtual-reality</Path>
+    <Description>&lt;p&gt;This workshop will provide a brief history of virtual (or VR) devices, and explore current medical applications. We will discuss the various iterations of VR throughout history, from the panoramic paintings of the 1600’s to current systems. We will also explore current health-related applications of VR, such as vision correction and neurorehabilitation. &lt;/p&gt;
+&lt;p&gt;Please contact Patrick Lyons, &lt;a href="mailto:patrick.lyons@temple.edu"&gt;patrick.lyons@temple.edu&lt;/a&gt; with any questions or to RSVP for a group of 15 or more.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a href="https://ginsburgstudy.temple.edu/event/4447898"&gt;https://ginsburgstudy.temple.edu/event/4447898&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Health Sciences</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>November 07, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>November 07, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;07/11/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-11-07T12:00:00-05:00"&gt;12:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-11-07T13:00:00-05:00"&gt;13:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1541610000</TimestampStart>
+    <TimestampEnd>1541613600</TimestampEnd>
+    <Tags>Health Sciences Libraries</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Health Sciences Center</Campus>
+    <Location>Ginsburg Health Sciences Library</Location>
+    <Room>Innovation Space</Room>
+    <Address>3500 N Broad St.</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19140</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Patrick Lyons</ContactName>
+    <ContactEmail>patrick.lyons@temple.edu</ContactEmail>
+    <ContactPhone>215-707-4953</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/HSL%20Virtual%20Reality.jpg?itok=5M0zDPM2&amp;c=8afc14bcd3f4b9396b73f7c3466a3859" alt="man with virtual reality glasses exploring human body" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44271</GUID>
+  </Event>
+  <Event>
+    <Title>Early Music Led by Shannon Merlino</Title>
+    <Path>https://events.temple.edu/early-music-led-by-shannon-merlino</Path>
+    <Description>&lt;p&gt;Be transported to another place and time while doctoral student Shannon Merlino leads a group of fellow musicians and colleagues in presenting early music at Paley Library.&lt;/p&gt;
+&lt;p dir="ltr"&gt;Light refreshments served. Boyer recital credit given.&lt;/p&gt;
+&lt;p dir="ltr"&gt;This performance is part of Temple University Libraries' &lt;a href="https://sites.temple.edu/performingartsnews/2018/08/20/beyond-the-notes-announces-2018-2019-season/"&gt;Beyond the Notes&lt;/a&gt; Series. It is presented in collaboration with the Center for the Performing and Cinematic Arts. &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Performance</Type>
+    <EventStartDate>November 14, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>November 14, 2018</EventEndDate>
+    <EventEndTime>12:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-11-14T12:00:00-05:00"&gt;14/11/2018 12:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1542214800</TimestampStart>
+    <TimestampEnd>1542214800</TimestampEnd>
+    <Tags>Beyond the Notes</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Anne Harlow</ContactName>
+    <ContactEmail>aharlow@temple.edu</ContactEmail>
+    <ContactPhone>215-204-5201</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ShannonMerlino2_.jpg?itok=A7Rn2e1A&amp;c=93466b17a48ca41f108f3640e7494798" alt="shannon merlino playing the violin" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>43101</GUID>
+  </Event>
+  <Event>
+    <Title>Systematic Reviews Overview</Title>
+    <Path>https://events.temple.edu/systematic-reviews-overview-3</Path>
+    <Description>&lt;p&gt;An introduction to what a systematic review is and the reasons for conducting one. We’ll uncover some of the essentials you’ll need to know before you even consider starting one. Learn what the current policies and regulations are and how they apply to you. We’ll also talk about ways the library can assist you with your future systematic review! This is a great workshop for anyone who is new to systematic reviews, is assisting with them, or just needs a refresher!&lt;/p&gt;
+&lt;p&gt;Please contact Stephanie Roth, &lt;a href="mailto:sgeffert@temple.edu"&gt;stephanie.roth@temple.edu&lt;/a&gt; with any questions or to RSVP for a group of 15 or more.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a href="https://ginsburgstudy.temple.edu/event/4353325"&gt;https://ginsburgstudy.temple.edu/event/4353325&lt;/a&gt;&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Health Sciences</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>November 14, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>November 14, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;14/11/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-11-14T12:00:00-05:00"&gt;12:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-11-14T13:00:00-05:00"&gt;13:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1542214800</TimestampStart>
+    <TimestampEnd>1542218400</TimestampEnd>
+    <Tags>Health Sciences Libraries</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Health Sciences Center</Campus>
+    <Location>Ginsburg Health Sciences Library</Location>
+    <Room>Computer Lab Room 248</Room>
+    <Address>3500 N Broad St.</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19140</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Undergraduate Students, Graduate Students</Audience>
+    <ContactName>Stephanie Roth</ContactName>
+    <ContactEmail>stephanie.roth@temple.edu</ContactEmail>
+    <ContactPhone>215-707-9469</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/systematicreviewtools%20%281%29.jpg?itok=8_XElx50&amp;c=4176dd8946dd85edaf567f6f64ca439d" alt="chart of systematic review tools" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>44276</GUID>
+  </Event>
+  <Event>
+    <Title>Zinemaking</Title>
+    <Path>https://events.temple.edu/zinemaking-1</Path>
+    <Description>&lt;p&gt;Makerspaces are not just about robots and virtual reality - critical making can also include low tech objects like small, self-published magazines, known as zines. Come to this hands-on workshop series to make zines using found and original images and text, scissors, staplers, and your favorite adhesives. You'll also get to handle zines from the Libraries’ collections, and learn why zines are still important in 2018. All materials provided, and you're welcome to bring your own. &lt;/p&gt;
+&lt;p&gt;There will be four workshops in this series. You are not required to come to every one, but each workshop will build on the last, so consistent attendance is encouraged.&lt;/p&gt;
+&lt;p&gt;Registe at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4503551&amp;source=gmail&amp;ust=1534856315980000&amp;usg=AFQjCNGl7_vWku7qOY1f80xgcOhQdmNAmw" href="https://paleystudy.temple.edu/event/4503551" target="_blank"&gt;https://paleystudy.temple.edu/event/4503551&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>November 14, 2018</EventStartDate>
+    <EventStartTime>3:00 pm</EventStartTime>
+    <EventEndDate>November 14, 2018</EventEndDate>
+    <EventEndTime>4:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;14/11/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-11-14T15:00:00-05:00"&gt;15:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-11-14T16:00:00-05:00"&gt;16:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1542225600</TimestampStart>
+    <TimestampEnd>1542229200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Caitlin Shanley</ContactName>
+    <ContactEmail>cshanley@temple.edu</ContactEmail>
+    <ContactPhone>215-204-3187</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/zineworkshoplogo_2.jpg?itok=sQTdPqvp&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="zine workshop logo" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42756</GUID>
+  </Event>
+  <Event>
+    <Title>Zinemaking</Title>
+    <Path>https://events.temple.edu/zinemaking-2</Path>
+    <Description>&lt;p&gt;Makerspaces are not just about robots and virtual reality - critical making can also include low tech objects like small, self-published magazines, known as zines. Come to this hands-on workshop series to make zines using found and original images and text, scissors, staplers, and your favorite adhesives. You'll also get to handle zines from the Libraries’ collections, and learn why zines are still important in 2018. All materials provided, and you're welcome to bring your own. &lt;/p&gt;
+&lt;p&gt;There will be four workshops in this series. You are not required to come to every one, but each workshop will build on the last, so consistent attendance is encouraged.&lt;/p&gt;
+&lt;p&gt;Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4503551&amp;source=gmail&amp;ust=1534856315980000&amp;usg=AFQjCNGl7_vWku7qOY1f80xgcOhQdmNAmw" href="https://paleystudy.temple.edu/event/4503551" target="_blank"&gt;https://paleystudy.temple.edu/event/4503551&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>November 28, 2018</EventStartDate>
+    <EventStartTime>3:00 pm</EventStartTime>
+    <EventEndDate>November 28, 2018</EventEndDate>
+    <EventEndTime>4:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;28/11/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-11-28T15:00:00-05:00"&gt;15:00&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-11-28T16:00:00-05:00"&gt;16:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1543435200</TimestampStart>
+    <TimestampEnd>1543438800</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Caitlin Shanley</ContactName>
+    <ContactEmail>cshanley@temple.edu</ContactEmail>
+    <ContactPhone>215-204-3187</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/zineworkshoplogo.jpg?itok=Sb0cHF-G&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="zinemaking" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>42761</GUID>
+  </Event>
+  <Event>
+    <Title>Temple University Percussion Ensemble Under the Direction of Phillip O’Banion</Title>
+    <Path>https://events.temple.edu/temple-university-percussion-ensemble-under-the-direction-of-phillip-o%E2%80%99banion</Path>
+    <Description>&lt;p&gt; &lt;/p&gt;
+
+&lt;p dir="ltr"&gt;Need to chill for an hour during finals? The Temple Percussion Ensemble will rock Paley Library, guaranteed!&lt;/p&gt;
+&lt;p dir="ltr"&gt;Light refreshments served. Boyer recital credit given.&lt;/p&gt;
+&lt;p dir="ltr"&gt;This performance is part of Temple University Libraries' &lt;a href="https://sites.temple.edu/performingartsnews/2018/08/20/beyond-the-notes-announces-2018-2019-season/"&gt;Beyond the Notes&lt;/a&gt; Series. It is presented in collaboration with the Center for the Performing and Cinematic Arts. &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Arts and Culture</Interest>
+    <Type>Performance</Type>
+    <EventStartDate>December 05, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>December 05, 2018</EventEndDate>
+    <EventEndTime>12:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single" property="dc:date" datatype="xsd:dateTime" content="2018-12-05T12:00:00-05:00"&gt;05/12/2018 12:00&lt;/span&gt;</Timestamp>
+    <TimestampStart>1544029200</TimestampStart>
+    <TimestampEnd>1544029200</TimestampEnd>
+    <Tags>Beyond the Notes</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Ground Floor Lecture Hall</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Anne Harlow</ContactName>
+    <ContactEmail>aharlow@temple.edu</ContactEmail>
+    <ContactPhone>215-204-5201</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/O%27Banion_Bio.jpg?itok=ZcawaHUf&amp;c=954368ec6c1638ceefc4c3e305f8fcc2" alt="headshot of Philip OBanion" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>43111</GUID>
+  </Event>
+  <Event>
+    <Title>Amplifying Your Research</Title>
+    <Path>https://events.temple.edu/amplifying-your-research-1</Path>
+    <Description>&lt;p&gt;Join us to learn how to effectively promote and share research online. We will discuss best practices for using social media, explain how to deposit research outputs in disciplinary repositories, and explore tools and platforms that can help authors expand their readership. Bring your laptop or borrow one from the Digital Scholarship Center.&lt;/p&gt;
+&lt;p&gt;	Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4203296&amp;source=gmail&amp;ust=1531997750098000&amp;usg=AFQjCNEqoork95Jmvp3HjZSU3pAeTEDjYw" href="https://paleystudy.temple.edu/event/4203296" target="_blank"&gt;https://paleystudy.temple.edu/event/4203296&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>February 12, 2019</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>February 12, 2019</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;12/02/2019 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2019-02-12T12:30:00-05:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2019-02-12T13:30:00-05:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1549992600</TimestampStart>
+    <TimestampEnd>1549996200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ResearchImpactBanner_Square%20%282%29_2.jpg?itok=vsLksmnP&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="research impact" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>41496</GUID>
+  </Event>
+  <Event>
+    <Title>Measuring Your Research Impact</Title>
+    <Path>https://events.temple.edu/measuring-your-research-impact-1</Path>
+    <Description>&lt;p&gt;Join us to gain strategies for identifying and measuring research impact using available online tools, like Web of Science and Scopus. Important buzzwords like citation metrics, impact factors, and the h-index will be explained and applied in a variety of disciplinary contexts. Relevant for faculty who may be going through the tenure and promotion process. Bring your laptop or borrow one from the Digital Scholarship Center.&lt;/p&gt;
+&lt;p&gt;	Register at &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4203300&amp;source=gmail&amp;ust=1531997750098000&amp;usg=AFQjCNHaPBLKoA5yf0ufQUXwfrq3-0m7LA" href="https://paleystudy.temple.edu/event/4203300" target="_blank"&gt;https://paleystudy.temple.edu/event/4203300&lt;/a&gt;.&lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Research</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>March 19, 2019</EventStartDate>
+    <EventStartTime>12:30 pm</EventStartTime>
+    <EventEndDate>March 19, 2019</EventEndDate>
+    <EventEndTime>1:30 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;19/03/2019 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2019-03-19T12:30:00-04:00"&gt;12:30&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2019-03-19T13:30:00-04:00"&gt;13:30&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1553013000</TimestampStart>
+    <TimestampEnd>1553016600</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Paley Library</Location>
+    <Room>Digital Scholarship Center</Room>
+    <Address>1210 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors></Sponsors>
+    <Audience>Faculty and Staff, Graduate Students</Audience>
+    <ContactName>Kristina De Voe</ContactName>
+    <ContactEmail>devoek@temple.edu</ContactEmail>
+    <ContactPhone>215-204-4583</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ResearchImpactBanner_Square%20%282%29.jpg?itok=oGZ6UK2o&amp;c=7d690f04f24a1156b3d9d3982d3bbc68" alt="research impact" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>0</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>0</Weight>
+    <GUID>41501</GUID>
+  </Event>
+</Events>

--- a/spec/fixtures/files/fuzzy_events_external.xml
+++ b/spec/fixtures/files/fuzzy_events_external.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Events>
+  <Event>
+    <Title>What, Me Worry?</Title>
+    <Path>https://events.temple.edu/how-to-use-a-library</Path>
+    <Description>&lt;p&gt;Join us for a webinar library best practices.&lt;/p&gt;</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 02, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>October 02, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;02/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538498700</TimestampStart>
+    <TimestampEnd>1538503200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Gladfelter Hall</Location>
+    <Room>Lecture Hall</Room>
+    <Address>1115 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Alfred E. Neuman</ContactName>
+    <ContactEmail>alfred.neuman@temple.edu</ContactEmail>
+    <ContactPhone>215-555-1234</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://library.temple.edu/sites/default/files/libraries/paley_tower.jpg" alt="Paley Library" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45321</GUID>
+  </Event>
+</Events>

--- a/spec/fixtures/files/fuzzy_events_internal.xml
+++ b/spec/fixtures/files/fuzzy_events_internal.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Events>
+  <Event>
+    <Title>How to Use a Library</Title>
+    <Path>https://events.temple.edu/how-to-use-a-library</Path>
+    <Description>&lt;p&gt;Join us for a webinar library best practices.&lt;/p&gt;</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 02, 2018</EventStartDate>
+    <EventStartTime>12:00 pm</EventStartTime>
+    <EventEndDate>October 02, 2018</EventEndDate>
+    <EventEndTime>1:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;02/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538498700</TimestampStart>
+    <TimestampEnd>1538503200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Addams Library</Location>
+    <Room>Room 1</Room>
+    <Address>1115 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Zaphod Beeblebrox</ContactName>
+    <ContactEmail>zaphod.beeblebrox@temple.edu</ContactEmail>
+    <ContactPhone>215-555-1234</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://library.temple.edu/sites/default/files/libraries/paley_tower.jpg" alt="Paley Library" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45321</GUID>
+  </Event>
+</Events>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
-# Add additional requires below this line. Rails is not loaded until this point!
+require "database_cleaner"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -56,4 +56,15 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/services/sync_events_spec.rb
+++ b/spec/services/sync_events_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "rails_helper" # ~> LoadError: cannot load such file -- rails_helper
+
+
+RSpec.describe SyncEvents, type: :service do
+  context "valid events" do
+    let(:sync_events) { SyncEvents.new(events_url: file_fixture("events.xml").to_path) }
+    let(:events) { sync_events.read_events }
+
+    it "extracts the event hash" do
+      expect(events.first["Title"]).to match(/^Data Transparency: Policies and Best Practices$/)
+    end
+
+    it "extracts all of the events" do
+      expect(events.count).to equal(37)
+    end
+
+    describe "maps events xml to db schema" do
+      subject { sync_events.record_hash(events.first) }
+
+      it "maps Title to title field" do
+        expect(subject["title"]).to match(events.first["Title"])
+      end
+
+      it "maps Description to description field" do
+        expect(subject["description"]).to match(events.first["Description"])
+      end
+
+      it "maps EventStartDate and EventStartTime to start_time field" do
+        expect(Time.parse(subject["start_time"])).to eq(Time.parse(events.first["EventStartDate"] + " " + events.first["EventStartTime"]))
+      end
+
+      it "maps EventEndDate and EventEndTime to start_time field" do
+        expect(Time.parse(subject["end_time"])).to eq(Time.parse(events.first["EventEndDate"] + " " + events.first["EventEndTime"]))
+      end
+
+      it "maps Location to external_building field" do
+        expect(subject["external_building"]).to match(events.first["Location"])
+      end
+
+      it "maps Room to external_building field" do
+        expect(subject["external_space"]).to match(events.first["Room"])
+      end
+
+      it "maps Address to external_building field" do
+        expect(subject["external_address"]).to match(events.first["Address"])
+      end
+
+      it "maps City to external_building field" do
+        expect(subject["external_city"]).to match(events.first["City"])
+      end
+
+      it "maps State to external_state field" do
+        expect(subject["external_state"]).to match(events.first["State"])
+      end
+
+      it "maps Zip to external_zip field" do
+        expect(subject["external_zip"]).to match(events.first["Zip"])
+      end
+
+      it "maps ContactName to external_contact_name field" do
+        expect(subject["external_contact_name"]).to match(events.first["ContactName"])
+      end
+
+      it "maps ContactEmail to external_contact_email field" do
+        expect(subject["external_contact_email"]).to match(events.first["ContactEmail"])
+      end
+
+      it "maps ContactPhone to external_contact_phone field" do
+        expect(subject["external_contact_phone"]).to match(events.first["ContactPhone"])
+      end
+
+      it "maps Canceled to cancelled field" do
+        expect(subject["cancelled"]).to match(events.first["Canceled"])
+      end
+
+      it "maps RegistrationStatus to registration_status field" do
+        expect(subject["registration_status"]).to match(events.first["RegistrationStatus"])
+      end
+
+      it "maps RegistrationLink to registration_link field", skip: "Missing registration link from source XML" do
+        expect(subject["registration_link"]).to match(events.first["RegistrationLink"])
+      end
+
+      it "maps document's digest to content_has field" do
+        expect(subject["content_hash"]).to match(Digest::SHA1.hexdigest(events.first.to_xml))
+      end
+    end
+  end
+
+  context "write event to event table" do
+    it "syncs events to the table" do
+      sync_events = SyncEvents.new(events_url: file_fixture("events.xml").to_path)
+      sync_events.sync
+      expect(Event.find_by(title: "Data Transparency: Policies and Best Practices")).to be
+      expect(Event.find_by(title: "Students, Labor Activism, and Publishing: From Radical America to Jacobin")).to be
+    end
+  end
+
+  context "fuzzy logic" do
+    before(:example) do
+      DatabaseCleaner.clean
+      @building = FactoryBot.create(:building)
+      @space = FactoryBot.create(:space, building: @building)
+      @person = FactoryBot.create(:person, spaces: [@space])
+    end
+
+    describe "contact" do
+      it "has a person reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_internal.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(person_id: @person.id)
+        expect(event.person_id).to eq @person.id
+        expect(event.external_contact_name).to eq nil
+      end
+      it "doesn't have a person reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_external.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(person_id: @person.id)
+        expect(event).to_not be
+      end
+    end
+
+    describe "location/building" do
+      it "has a building reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_internal.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(building_id: @building.id)
+        expect(event.building_id).to eq @building.id
+        expect(event.building.name).to eq @building.name
+        expect(event.external_building).to eq nil
+      end
+      it "doesn't have a building reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_external.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(building_id: @building.id)
+        expect(event).to_not be
+      end
+    end
+
+    context "space" do
+      it "has a space reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_internal.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(space_id: @space.id)
+        expect(event.space_id).to eq @space.id
+        expect(event.space.name).to eq @space.name
+        expect(event.external_space).to eq nil
+      end
+      it "doesn't have a space reference" do
+        @sync_events = SyncEvents.new(events_url: file_fixture("fuzzy_events_external.xml").to_path)
+        @events = @sync_events.read_events
+        @sync_events.sync
+        event = Event.find_by(space_id: @space.id)
+        expect(event).to_not be
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Create Event Sync as a service
- Event model association must be optional (Rails 5 made it required by
  default)
- Elide event fields displayed in default views (to make development life easier)

Rake task to read events from external source

Integrate fuzzy search

Clean up database so we can run different data fixtures without
interference from previous tests