### PR TITLE
Add convenience wrappers for fuzzy service

### DIFF
--- a/app/services/fuzzy_find/building.rb
+++ b/app/services/fuzzy_find/building.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FuzzyFind
+  module Building
+    def self.find(needle, attribute: :name, addl_attribute: {})
+      ::FuzzyFind::FinderService.call(
+        needle: needle,
+        haystack_model: ::Building,
+        attribute: attribute,
+        addl_attribute: addl_attribute
+        )
+    end
+  end
+end

--- a/app/services/fuzzy_find/event.rb
+++ b/app/services/fuzzy_find/event.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FuzzyFind
+  module Event
+    def self.find(needle, attribute: :title, addl_attribute: {})
+      ::FuzzyFind::FinderService.call(
+        needle: needle,
+        haystack_model: ::Event,
+        attribute: attribute,
+        addl_attribute: addl_attribute
+        )
+    end
+  end
+end

--- a/app/services/fuzzy_find/finder_service.rb
+++ b/app/services/fuzzy_find/finder_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module FuzzyFinderService
+module FuzzyFind::FinderService
   require "fuzzy_match"
 
   class Error < StandardError; end
@@ -59,7 +59,7 @@ module FuzzyFinderService
         #Eager load classes if not in production (is already
         # done in production) so ApplicationRecord.descendants works
         Rails.application.eager_load! unless Rails.env.production?
-        raise FuzzyFinderService::Error.new(
+        raise Error.new(
           "#{model} is not an ActiveModel in this application"
         ) unless ApplicationRecord.descendants.include? model
       end

--- a/app/services/fuzzy_find/person.rb
+++ b/app/services/fuzzy_find/person.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module FuzzyFind
+  module Person
+    def self.find(needle, attribute: :name, addl_attribute: {})
+      ::FuzzyFind::FinderService.call(
+        needle: needle,
+        haystack_model: ::Person,
+        attribute: attribute,
+        addl_attribute: addl_attribute
+        )
+    end
+  end
+end

--- a/app/services/fuzzy_find/space.rb
+++ b/app/services/fuzzy_find/space.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FuzzyFind
+  module Space
+    def self.find(needle, attribute: :name, addl_attribute: {})
+      ::FuzzyFind::FinderService.call(
+        needle: needle,
+        haystack_model: ::Space,
+        attribute: attribute,
+        addl_attribute: addl_attribute
+        )
+    end
+
+    def self.by_name_and_building(name:, building:)
+      self.call(
+        name,
+        addl_attribute: { building: building }
+        )
+    end
+  end
+end

--- a/spec/services/fuzzy_find/building_spec.rb
+++ b/spec/services/fuzzy_find/building_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FuzzyFind::Building do
+
+  before do
+    @service = FuzzyFind::FinderService = double("fuzzy double")
+  end
+  let(:building_name) { "Your House!" }
+  let(:building) { described_class.find(building_name) }
+
+  describe "#find" do
+    it "passes expected default params to FuzzyFind::FinderService" do
+      expect(@service).to receive(:call)
+        .with(
+          needle: building_name,
+          haystack_model: ::Building,
+          attribute: :name,
+          addl_attribute: {}
+        )
+      building
+    end
+  end
+end

--- a/spec/services/fuzzy_find/event_spec.rb
+++ b/spec/services/fuzzy_find/event_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FuzzyFind::Event do
+
+  before do
+    @service = FuzzyFind::FinderService = double("fuzzy double")
+  end
+  let(:event_name) { "Party at Your House!" }
+  let(:event) { described_class.find(event_name) }
+
+  describe "#find" do
+    it "passes expected default params to FuzzyFind::FinderService" do
+      expect(@service).to receive(:call)
+        .with(
+          needle: event_name,
+          haystack_model: ::Event,
+          attribute: :title,
+          addl_attribute: {}
+        )
+      event
+    end
+  end
+end

--- a/spec/services/fuzzy_find/finder_service_spec.rb
+++ b/spec/services/fuzzy_find/finder_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FuzzyFinderService do
+RSpec.describe FuzzyFind::FinderService do
 
   class UndefinedModel; end
   class MockModel < ApplicationRecord
@@ -48,8 +48,8 @@ RSpec.describe FuzzyFinderService do
 
     context "haystack_model is not a defined model" do
       let(:haystack_model) { UndefinedModel }
-      it "raises a FuzzyFinderService Error" do
-        expect { called_service }.to raise_error(FuzzyFinderService::Error)
+      it "raises a FuzzyFind::FindererService Error" do
+        expect { called_service }.to raise_error(described_class::Error)
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe FuzzyFinderService do
 
       context "with a similar name" do
         it "returns the expected person" do
-          expect(FuzzyFinderService.call(
+          expect(described_class.call(
                    needle: "Newish Person",
                    haystack_model: Person,
                    attribute: :name)
@@ -80,7 +80,7 @@ RSpec.describe FuzzyFinderService do
         context "and an simple additional attribute" do
           it "returns the expected person" do
             expect(
-              FuzzyFinderService.call(
+              described_class.call(
                 needle: "Newish Person",
                 haystack_model: Person,
                 attribute: :name,
@@ -94,7 +94,7 @@ RSpec.describe FuzzyFinderService do
           context "passing an object" do
             it "returns the expected person" do
               expect(
-                FuzzyFinderService.call(
+                described_class.call(
                   needle: "Newish Person",
                   haystack_model: Person,
                   attribute: :name,
@@ -107,7 +107,7 @@ RSpec.describe FuzzyFinderService do
           context "passing an id string" do
             it "returns the expected person" do
               expect(
-                FuzzyFinderService.call(
+                described_class.call(
                   needle: "Newish Person",
                   haystack_model: Person,
                   attribute: :name,
@@ -120,7 +120,7 @@ RSpec.describe FuzzyFinderService do
           context "passing an id int" do
             it "returns the expected person" do
               expect(
-                FuzzyFinderService.call(
+                described_class.call(
                   needle: "Newish Person",
                   haystack_model: Person,
                   attribute: :name,
@@ -134,7 +134,7 @@ RSpec.describe FuzzyFinderService do
 
       context "with a name that does not match at all" do
         it "returns nil" do
-          expect(FuzzyFinderService.call(
+          expect(described_class.call(
                    needle: "kikkilij mqwwewe",
                    haystack_model: Person,
                    attribute: :name)

--- a/spec/services/fuzzy_find/person_spec.rb
+++ b/spec/services/fuzzy_find/person_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FuzzyFind::Person do
+
+  before do
+    @service = FuzzyFind::FinderService = double("fuzzy double")
+  end
+  let(:person_name) { "Your Name" }
+  let(:person) { described_class.find(person_name) }
+
+  describe "#find" do
+    it "passes expected default params to FuzzyFind::FinderService" do
+      expect(@service).to receive(:call)
+        .with(
+          needle: person_name,
+          haystack_model: ::Person,
+          attribute: :name,
+          addl_attribute: {}
+        )
+      person
+    end
+  end
+end

--- a/spec/services/fuzzy_find/space_spec.rb
+++ b/spec/services/fuzzy_find/space_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FuzzyFind::Space do
+
+  before do
+    @service = FuzzyFind::FinderService = double("fuzzy double")
+  end
+  let(:space_name) { "Your Kitchen" }
+  let(:space) { described_class.find(space_name) }
+
+  describe "#find" do
+    it "passes expected default params to FuzzyFind::FinderService" do
+      expect(@service).to receive(:call)
+        .with(
+          needle: space_name,
+          haystack_model: ::Space,
+          attribute: :name,
+          addl_attribute: {}
+        )
+      space
+    end
+  end
+end


### PR DESCRIPTION
Wraps the models likely to need to be found by fuzzy matches in
convenience methods to make them easier to use.