### PR TITLE
Restore phone and email fields in groups

### DIFF
--- a/db/migrate/20181025181642_remove_phone_and_email_from_groups.rb
+++ b/db/migrate/20181025181642_remove_phone_and_email_from_groups.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class RemovePhoneAndEmailFromGroups < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :groups, :phone_number, :string
-    remove_column :groups, :email_address, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_25_181642) do
+ActiveRecord::Schema.define(version: 2018_10_23_203933) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -144,6 +144,8 @@ ActiveRecord::Schema.define(version: 2018_10_25_181642) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "description"
+    t.string "phone_number"
+    t.string "email_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "group_type"


### PR DESCRIPTION
- Removing these fields caused deployment to fail. Restoring
  just the fields. Leaving the back-end code in place.