### PR TITLE
Groups: removed lingering phone and email from schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     memoist (0.16.0)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
-    method_source (0.9.0)
+    method_source (0.9.1)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_23_203933) do
+ActiveRecord::Schema.define(version: 2018_10_25_181642) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -144,8 +144,6 @@ ActiveRecord::Schema.define(version: 2018_10_23_203933) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.string "phone_number"
-    t.string "email_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "group_type"


### PR DESCRIPTION
The phone and email fields for groups should have also been removed from the schema.