### PR TITLE
Refactor group, spaces, and person factories

### DIFF
--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -5,11 +5,7 @@ require "rails_helper"
 RSpec.describe GroupsController, type: :controller do
   include Devise::Test::ControllerHelpers
 
-  #let (:person) { FactoryBot.build(:person) }
-  let(:building) { FactoryBot.create(:building) }
-  let(:space) { FactoryBot.create(:space, building: building) }
-  let(:chair_person) { FactoryBot.create(:person, spaces: [space]) }
-  let(:group) { FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person]) }
+  let(:group) { FactoryBot.create(:group) }
 
   describe "GET #index" do
     it "returns http success" do

--- a/spec/controllers/persons_controller_spec.rb
+++ b/spec/controllers/persons_controller_spec.rb
@@ -6,11 +6,7 @@ RSpec.describe PersonsController, type: :controller do
 
   include Devise::Test::ControllerHelpers
 
-  let(:building) { FactoryBot.create(:building) }
-  let(:space) { FactoryBot.create(:space, building: building) }
-  let(:chair_person) { FactoryBot.create(:person, spaces: [space]) }
-  let(:group) { FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person]) }
-  let(:person) { person = FactoryBot.create(:person, groups: [group], spaces: [space]) }
+  let(:person) { FactoryBot.create(:person) }
 
   describe "GET #index" do
     it "returns http success" do

--- a/spec/controllers/spaces_controller_spec.rb
+++ b/spec/controllers/spaces_controller_spec.rb
@@ -6,13 +6,7 @@ RSpec.describe SpacesController, type: :controller do
 
   include Devise::Test::ControllerHelpers
 
-  let(:space) {
-    building = FactoryBot.create(:building)
-    space = FactoryBot.build(:space)
-    space.building_id = building.id
-    space.save
-    space
-  }
+  let(:space) { FactoryBot.create(:space) }
 
   describe "GET #index" do
     it "returns http success" do

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -5,11 +5,8 @@ FactoryBot.define do
     sequence(:name) { |n| "Conquerors #{n}" }
     description { "Able bodied men and women of adventure" }
     group_type { "Department" }
-    # Add related objects in create.
-    # e.g.
-    #   let(:building) { FactoryBot.create(:building) }
-    #   let(:space) { FactoryBot.create(:space, building: building) }
-    #   let(:person) { FactoryBot.create(:person, buildings: [building], spaces: [space]) }
-    #   let(:group) { FactoryBot.create(:group, persons: [person], buildings: [building], spaces: [space]) }
+    persons { [ FactoryBot.create(:person, spaces: [ FactoryBot.create(:space) ]) ] }
+    chair_dept_heads { [ FactoryBot.create(:person, spaces: [ FactoryBot.create(:space) ]) ] }
+    space { FactoryBot.create(:space) }
   end
 end

--- a/spec/factories/persons.rb
+++ b/spec/factories/persons.rb
@@ -11,9 +11,6 @@ FactoryBot.define do
     research_identifier { "PREZBEEB" }
     personal_site { "http://prez.example.com" }
     springshare_id { "0123-4567-8901" }
-    # Add related objects in create.
-    # e.g.
-    spaces { [FactoryBot.create(:space, building: FactoryBot.create(:building))] }
-    #   let(:person) { FactoryBot.create(:person, spaces: [space]) }
+    spaces { [FactoryBot.create(:space)] }
   end
 end

--- a/spec/factories/spaces.rb
+++ b/spec/factories/spaces.rb
@@ -11,26 +11,11 @@ FactoryBot.define do
     phone_number { "2155551213" }
     email { "mmuffley@example.com" }
     image { "https://diefenbunker.files.wordpress.com/2012/05/dr-strangelove-warroom.jpg" }
+    association :building
 
-    factory :space_with_building do
-      association :building
-
-      factory :space_with_people do
-        after(:create) do |space|
-          create_list(:person, 1, spaces: [space])
-        end
-      end
-
-      factory :space_with_groups do
-        after(:create) do |space|
-          create_list(:group, 1, space: space)
-        end
-      end
-
-      factory :space_with_parent do
-        after(:create) do |space|
-          space.ancestry = "#{create(:space).id}"
-        end
+    factory :space_with_parent do
+      after(:create) do |space|
+        space.ancestry = "#{create(:space).id}"
       end
     end
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -4,11 +4,6 @@ require "rails_helper"
 
 RSpec.describe Group, type: :model do
 
-  let(:building) { FactoryBot.create(:building) }
-  let(:space) { FactoryBot.create(:space, building: building) }
-  let(:person) { FactoryBot.build(:person, spaces: [space]) }
-  let(:chair_person) { FactoryBot.create(:person, spaces: [space]) }
-
   context "Group Class Attributes" do
     subject { Group.new.attributes.keys }
 
@@ -19,15 +14,15 @@ RSpec.describe Group, type: :model do
 
   describe "has many through member" do
     context "Attach person" do
-      let(:group) { FactoryBot.create(:group, persons: [person], space: space, chair_dept_heads: [chair_person]) }
       example "valid" do
-        expect(group.persons.last.last_name).to match(/#{Person.last.last_name}/)
-        expect(group.persons.last.first_name).to match(/#{Person.last.first_name}/)
+        person = FactoryBot.create(:person)
+        group = FactoryBot.create(:group, persons: [person])
+        expect(group.persons).to include(person)
       end
     end
 
     context "No person" do
-      let(:group) { FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person]) }
+      let(:group) { FactoryBot.create(:group, persons: []) }
       example "valid" do
         expect { group.save! }.to_not raise_error
       end
@@ -36,37 +31,38 @@ RSpec.describe Group, type: :model do
 
   describe "has one chair_dept_heads" do
     context "Attach a chair_dept_heads" do
-      let(:group) { FactoryBot.create(:group, persons: [], chair_dept_heads: [chair_person], space: space) }
       example "valid" do
-        expect(group.chair_dept_heads.last.last_name).to match /#{chair_person.last_name}/
+        chair_person = FactoryBot.create(:person, spaces: [FactoryBot.create(:space)])
+        group = FactoryBot.create(:group, chair_dept_heads: [chair_person])
+        expect(group.chair_dept_heads).to eq([chair_person])
       end
     end
     context "Change a chair_dept_heads" do
-      let(:chair_person_1) { FactoryBot.create(:person, spaces: [space]) }
-      let(:chair_person_2) { FactoryBot.create(:person, last_name: "Fawlty", first_name: "Basil", spaces: [space]) }
-      let(:group) { FactoryBot.create(:group, persons: [], chair_dept_heads: [chair_person_1], space: space) }
       example "valid" do
-        expect(group.chair_dept_heads.last.last_name).to match /#{chair_person_1.last_name}/
+        chair_person_1 = FactoryBot.create(:person, spaces: [FactoryBot.create(:space)])
+        chair_person_2 = FactoryBot.create(:person, last_name: "Fawlty", first_name: "Basil", spaces: [FactoryBot.create(:space)])
+        group = FactoryBot.create(:group, persons: [], chair_dept_heads: [chair_person_1])
+        expect(group.chair_dept_heads).to eq([chair_person_1])
         group.chair_dept_heads = [chair_person_2]
         group.save!
-        expect(group.chair_dept_heads.last.last_name).to match /#{chair_person_2.last_name}/
+        expect(group.chair_dept_heads).to eq([chair_person_2])
       end
     end
   end
 
   describe "has many spaces through" do
     context "Attach space" do
-      let(:group) { FactoryBot.create(:group, persons: [person], space: space, chair_dept_heads: [chair_person]) }
-      example "valid" do
+      example "Group space is the last space created" do
+        group = FactoryBot.create(:group)
         expect { group.save! }.to_not raise_error
-        expect(group.space.name).to match(/#{Space.first.name}/)
+        expect(group.space).to eq(Space.last)
       end
     end
   end
 
 
   describe "field validators" do
-    let(:group) { FactoryBot.build(:group, space: space, chair_dept_heads: [chair_person]) }
+    let(:group) { FactoryBot.build(:group) }
 
     context "Space reference" do
       example "valid space ID" do
@@ -100,7 +96,7 @@ RSpec.describe Group, type: :model do
   context "Policy reference" do
     example "Add group policy" do
       policy = FactoryBot.create(:policy)
-      group = FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person])
+      group = FactoryBot.create(:group)
       group.policies << policy
       expect(group.policies).to include(policy)
     end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Space, type: :model do
     ]
     optional_references.each do |f|
       example "missing #{f}" do
-        space = FactoryBot.build(:space_with_building)
+        space = FactoryBot.build(:space)
         space[f] = nil
         expect { space.save! }.to_not raise_error
       end
@@ -45,7 +45,7 @@ RSpec.describe Space, type: :model do
 
   describe "field validators" do
 
-    let (:space) { FactoryBot.build(:space_with_building) }
+    let (:space) { FactoryBot.build(:space) }
 
     context "Email validation" do
       example "valid email" do
@@ -82,7 +82,7 @@ RSpec.describe Space, type: :model do
         expect { space.save! }.to_not raise_error
       end
       example "no building" do
-        space = FactoryBot.build(:space)
+        space = FactoryBot.build(:space, building: nil)
         expect { space.save! }.to raise_error(/Building can't be blank/)
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe Space, type: :model do
     context "Policy reference" do
       example "Add space policy" do
         policy = FactoryBot.create(:policy)
-        space = FactoryBot.create(:space_with_building)
+        space = FactoryBot.create(:space)
         space.policies << policy
         expect(space.policies).to include(policy)
       end

--- a/spec/views/groups/show.html.erb_spec.rb
+++ b/spec/views/groups/show.html.erb_spec.rb
@@ -3,26 +3,21 @@
 require "rails_helper"
 
 RSpec.describe "groups/show.html.erb", type: :view do
-  let(:building) { FactoryBot.create(:building) }
-  let(:space) { FactoryBot.create(:space, building: building) }
-  let(:person) { FactoryBot.create(:person, spaces: [space]) }
-  let(:chair_person) { FactoryBot.create(:person, spaces: [space]) }
-
   it "displays the sample group name" do
-    @group = FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person])
+    @group = FactoryBot.create(:group)
     render
     expect(rendered).to match /#{@group.name}/
   end
 
   it "displays the person" do
-    @group = FactoryBot.create(:group, persons: [person], space: space, chair_dept_heads: [chair_person])
+    @group = FactoryBot.create(:group)
     render
     expect(rendered).to match /#{Person.first.last_name}/
   end
 
   it "displays the space" do
-    @group = FactoryBot.create(:group, space: space, chair_dept_heads: [chair_person])
+    @group = FactoryBot.create(:group)
     render
-    expect(rendered).to match /#{Space.first.name}/
+    expect(rendered).to match /#{@group.space.name}/
   end
 end

--- a/spec/views/persons/show.html.erb_spec.rb
+++ b/spec/views/persons/show.html.erb_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "persons/show.html.erb", type: :view do
-  let (:building) { FactoryBot.create(:building) }
-  let (:space) { FactoryBot.create(:space, building: building) }
+  let (:space) { FactoryBot.create(:space) }
   it "displays the sample person's last name" do
-    @building = building
+    @building = space.building
     @person = FactoryBot.create(:person, spaces: [space])
     render
     expect(rendered).to match /#{@person.last_name}/


### PR DESCRIPTION
- Move creation of associated objects in Group, Space, and Person
  from spec into factory where it belongs. Removes redundant setup
  of these dependencies from all of the tests
- Make building association creation in space the default condition
  so we don't have to have :space_with_building in all of the specs.
  In order to test for missing building in space, we set
  space.buidling to nil.