### PR TITLE
Adding custom highlights to view page (main homepage only)

### DIFF
--- a/app/assets/stylesheets/partials/_card-rows.scss
+++ b/app/assets/stylesheets/partials/_card-rows.scss
@@ -43,7 +43,7 @@
 
 	/* //////////////////////////// TOP COLORED BOXES ///////////////////////////// */ 
 
-	.ctaFirst {
+	.ctaFirst, .cta1st {
 		background-color: $foamgreen;
 		color: $white;
 		border-top-left-radius: 42px;
@@ -53,7 +53,7 @@
 			color: $black;
 		}
 	}
-	.ctaMidOne, .ctaMid {
+	.ctaMidOne, .ctaMid, .cta2nd {
 		background-color: $seagreen;
 		color: $white;
 		.card-title.complement {
@@ -61,7 +61,7 @@
 			color: $black;
 		}
 	}
-	.ctaMidTwo {
+	.ctaMidTwo, .cta3rd {
 		background-color: $purple;
 		color: $white;
 		.card-title.complement {
@@ -69,7 +69,7 @@
 			color: $black;
 		}
 	}	
-	.ctaLast {
+	.ctaLast, .cta4th {
 		background-color: $darkgold;
 		border-top-right-radius: 42px;
 		border-bottom-right-radius: 42px;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  before_action :set_date, :todays_date, only: [:home, :hsl, :ambler]
+  before_action :set_date, :todays_date, :get_highlights, only: [:home, :hsl, :ambler]
 
   def get_highlights
     @highlights = Highlight.where(promoted: true).take(4)

--- a/app/dashboards/highlight_dashboard.rb
+++ b/app/dashboards/highlight_dashboard.rb
@@ -15,7 +15,7 @@ class HighlightDashboard < Administrate::BaseDashboard
     title: Field::String,
     blurb: Field::Text,
     link: Field::String,
-    date: Field::DateTime.with_options(format: "%A %B %Y"),
+    date: Field::DateTime.with_options(format: "%A %B %Y"), #optional field, can't format blank field
     time: Field::Time,
     type_of_highlight: Field::Select.with_options(
       collection: Rails.configuration.highlight_types,

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -63,6 +63,8 @@
 	</div>
 </div>
 
+<% unless @highlights.blank? %>
+
 <div class="row">
 	<div class="col">
 		<div class="vertical-stripes">
@@ -72,47 +74,25 @@
 </div>
 
 <div class="row ctaRow news">
-	<div class="col col-sm-6 col-lg-4 col-xl-3">
-		<div class="card ctaFirst">
-			<%= image_tag('researchhelp.jpg', class: "card-img-top", alt: "Card image cap") %>
-		  <div class="card-body">
-		    <span class="card-title">Help with Research</span>
-		    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-		    <%= link_to "See more >", "#", class: 'see-more' %>
-		  </div>
-		</div>
-	</div>
-	<div class="col col-sm-6 col-lg-4 col-xl-3">
-		<div class="card ctaMid">
-			<%= image_tag('researchhelp.jpg', class: "card-img-top", alt: "Card image cap") %>
-		  <div class="card-body">
-		    <span class="card-title">Find a study space</span>
-		    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-		    <%= link_to "See more >", "#", class: 'see-more' %>
-		  </div>
-		</div>
-	</div>
-	<div class="col col-sm-6 col-lg-4 col-xl-3">
-		<div class="card ctaMid">
-			<%= image_tag('researchhelp.jpg', class: "card-img-top", alt: "Card image cap") %>
-		  <div class="card-body">
-		    <span class="card-title">Print my paper</span>
-		    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-		    <%= link_to "See more >", "#", class: 'see-more' %>
-		  </div>
-		</div>
-	</div>
-	<div class="col col-sm-6 col-lg-4 col-xl-3">
-		<div class="card ctaLast">
-			<%= image_tag('researchhelp.jpg', class: "card-img-top", alt: "Card image cap") %>
-		  <div class="card-body">
-		    <span class="card-title">Print my paper</span>
-		    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-		    <%= link_to "See more >", "#", class: 'see-more' %>
-		  </div>
-		</div>
-	</div>
+	<% @highlights.each_with_index do |highlight, index| %>
+			<div class="col col-sm-6 col-lg-4 col-xl-3">
+				<div class="card cta<%= (index+1).ordinalize %> ">
+
+			    <% if highlight.photo.attached?  %>
+			      <%= image_tag highlight.photo.variant(resize: '360x360', gravity: 'center'), class: "card-img-top", alt: "alt text field needs to be added to model" %>
+			    <% else %>
+			      <%= image_tag "T.gif", style: 'width: 300px;' %>
+			    <% end %>
+				  <div class="card-body">
+				    <span class="card-title"><%= highlight.title %></span>
+				    <p class="card-text"><%= highlight.blurb %></p>
+				    <%= link_to "See more >", highlight.link, class: 'see-more' %>
+				  </div>
+				</div>
+			</div>
+		<% end %>
 </div>
+<% end %>
 
 <div class="row">
 	<div class="col">


### PR DESCRIPTION
This adds the highlights, previously modelled and dashboarded, to the main homepage.

The highlights did not exist when the current homepage was created, so they were mocked up with static data.

The date and time fields are throwing errors if left blank and need to be looked at in future to prevent this.