### PR TITLE
Turned column heading in footer into links to model index pages.

### DIFF
--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -11,18 +11,33 @@
 }
 #footer-buildings {
 	color: $lightest-purple;
+	a {
+		color: $lightest-purple!important;
+	}
 }
 #footer-spaces {
 	color: $baby-puke-green;
+	a {
+		color: $baby-puke-green!important;
+	}
 }
 #footer-services {
 	color: $honeydew;
+	a {
+		color: $honeydew!important;
+	}
 }
 #footer-groups {
 	color: $musk-melon;
+	a {
+		color: $musk-melon!important;
+	}
 }
 #footer-collections {
 	color: $saffron;
+	a {
+		color: $saffron!important;
+	}
 }
 #site-footer {
 		background-color: $footer-gray;

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -25,7 +25,7 @@
 
       <div class="postscript row" style="margin-top: 56px;">      
         <div class="col col-sm-2" id="footer-buildings">
-          <strong>Buildings</strong>
+          <%= link_to "Buildings", {controller: :buildings, action: "index"}, style: "font-weight:600" %>
           <hr />
           <ul>
             <li>Building 1</li>
@@ -38,7 +38,7 @@
             </ul>
         </div>
         <div class="col col-sm-2" id="footer-spaces">
-          <strong>Spaces</strong>
+          <%= link_to "Spaces", {controller: :spaces, action: "index"}, style: "font-weight:600" %>
           <hr style="border: solid white 1px;color: white" />
           <ul>
             <li>Space 1</li>
@@ -51,7 +51,7 @@
             </ul>
         </div>
         <div class="col col-sm-2" id="footer-services">
-          <strong>Services</strong>
+          <%= link_to "Services", {controller: :services, action: "index"}, style: "font-weight:600" %>
           <hr style="border: solid white 1px;color: white" />
           <ul>
             <li>Service 1</li>
@@ -64,7 +64,7 @@
             </ul>
         </div>
         <div class="col col-sm-2" id="footer-groups">
-          <strong>Groups</strong>
+          <%= link_to "Groups", {controller: :groups, action: "index"}, style: "font-weight:600" %>
           <hr style="border: solid white 1px;color: white" />
           <ul>
             <li>Group 1</li>
@@ -78,6 +78,7 @@
         </div>
         <div class="col col-sm-2" id="footer-collections">
           <strong>Collections</strong>
+          <%# link_to "Collections", {controller: :collections, action: "index"}, style: "font-weight:600" %>
           <hr style="border: solid white 1px;color: white" />
           <ul>
             <li>Collection 1</li>


### PR DESCRIPTION
This is for ease of navigation to stake holders checking the site, so they don't have to type anything into the address bar to browse the main sections of the site.