### PR TITLE
Fix intended audience being rejected as not permitted

### DIFF
--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -17,7 +17,7 @@ class ServiceDashboard < Administrate::BaseDashboard
     access_link: Field::String,
     service_policies: DescriptionField,
     intended_audience: MultiSelectField.with_options(
-      collection: Rails.configuration.audience_types,
+      collection: Rails.configuration.audience_types
     ),
     service_category: Field::Select.with_options(
       collection: Rails.configuration.service_types

--- a/app/fields/multi_select_field.rb
+++ b/app/fields/multi_select_field.rb
@@ -6,4 +6,12 @@ class MultiSelectField < Administrate::Field::Select
   def to_s
     data
   end
+
+  def self.permitted_attribute(attribute, _options = nil)
+    { attribute.to_sym => [] }
+  end
+
+  def permitted_attribute
+    self.class.permitted_attribute(attribute)
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -14,11 +14,11 @@ class Service < ApplicationRecord
   has_many :service_group
   has_many :related_groups, through: :service_group, source: :group
 
-  before_create :remove_empty_audience
+  before_validation :remove_empty_audience
   before_validation :sanitize_description
 
   def remove_empty_audience
     # Rails tends to return an empty string in multi-selects array
-    intended_audience.reject! { |a| a.empty? }
+    intended_audience&.reject! { |a| a.empty? }
   end
 end

--- a/app/views/fields/multi_select_field/_form.html.erb
+++ b/app/views/fields/multi_select_field/_form.html.erb
@@ -2,8 +2,16 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field" id="<%= field.attribute %>_select">
-  <%= f.select(field.attribute, nil, {}, multiple: true, size: field.selectable_options.count) do %>
-    <%= options_for_select(field.selectable_options, field.data) %>
-  <% end %>
+  <%= f.select(
+        field.attribute,
+        options_from_collection_for_select(
+        field.selectable_options,
+          :to_s,
+          :to_s,
+          field.data.presence,
+        ),
+        { include_blank: false}, 
+        { multiple: true, size: field.selectable_options.count }
+      )  %>
   <input type="button" id="<%= field.attribute %>_select_all" class="select-all" name="select_all" value="Select All">
 </div>

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Service, type: :model do
     end
 
     example "Missing intended audience" do
-      service = FactoryBot.build(:service, intended_audience: "")
+      service = FactoryBot.build(:service, intended_audience: [""])
       expect { service.save! }.to raise_error(/Intended audience can't be blank/)
     end
 


### PR DESCRIPTION
Services were not able to be saved as intended audience was not being permitted as a param, and thus was always nil.