### PR TITLE
Make Event Sync Service call do it all

### DIFF
--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -4,7 +4,7 @@ require "open-uri"
 
 class SyncService::Events
   def self.call(events_url: nil)
-    new(events_url: events_url)
+    new(events_url: events_url).sync
   end
 
   def initialize(params = {})

--- a/lib/tasks/events_sync.rake
+++ b/lib/tasks/events_sync.rake
@@ -4,8 +4,6 @@ namespace :sync do
   desc "sync events"
   task :events, [:path] => :environment do |t, args|
     args.with_defaults(path: nil)
-    sync_events = SyncService::Events.call(events_url: args[:path])
-    events = sync_events.read_events
-    sync_events.sync
+    SyncService::Events.call(events_url: args[:path])
   end
 end


### PR DESCRIPTION
Simplifies usage of SyncSevice::Events.call by calling sync inside the method, so users of the service do not have to do so.