### PR TITLE
Administrate show page errors

### DIFF
--- a/app/views/fields/multi_select_field/_show.html.erb
+++ b/app/views/fields/multi_select_field/_show.html.erb
@@ -1,3 +1,4 @@
+<% unless field.data.nil? %>
 <ol>
   <% field.data.each do |item| %>
   <li>
@@ -5,3 +6,4 @@
   </li>
   <% end %>
 </ol>
+<% end %>


### PR DESCRIPTION
Administrate show page for person was erroring when no subject specialties were assigned to a person.