### PR TITLE
MAN-27 News and highlights section

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -175,7 +175,7 @@ form {
 	  	background-color:white!important;
 	  	color: $dark-grey;
 	  	margin:auto;
-	  	height:88px;
+	  	height:56px;
   	}
   }
 }
@@ -183,4 +183,26 @@ img.map {
 	min-height: 100%;
 	height: 100%;
 	max-height: 100%!important;
+}
+
+.highlight.container {
+	.ctaFirst {
+		float: left;
+		border-color: #1f9584;
+		border-radius:14px;
+		width:420px;
+		overflow: hidden;
+		.card-body span {
+			font-weight:600;
+		}
+	}
+	.description {
+		float: left;
+		padding-left: 35px;
+		padding-top: 21px;
+		h3 {
+			font-size: x-large;
+		}
+	}
+
 }

--- a/app/dashboards/highlight_dashboard.rb
+++ b/app/dashboards/highlight_dashboard.rb
@@ -14,9 +14,8 @@ class HighlightDashboard < Administrate::BaseDashboard
     photo: PhotoField,
     title: Field::String,
     blurb: Field::Text,
+    link_label: Field::String,
     link: Field::String,
-    date: Field::DateTime.with_options(format: "%A %B %Y"), #optional field, can't format blank field
-    time: Field::Time,
     type_of_highlight: Field::Select.with_options(
       collection: Rails.configuration.highlight_types,
       multiple: true,
@@ -43,9 +42,8 @@ class HighlightDashboard < Administrate::BaseDashboard
     :photo,
     :title,
     :blurb,
+    :link_label,
     :link,
-    :date,
-    :time,
     :type_of_highlight,
     :tags,
   ].freeze
@@ -57,9 +55,8 @@ class HighlightDashboard < Administrate::BaseDashboard
     :photo,
     :title,
     :blurb,
+    :link_label,
     :link,
-    :date,
-    :time,
     :type_of_highlight,
     :tags,
     :promoted,

--- a/app/views/highlights/show.html.erb
+++ b/app/views/highlights/show.html.erb
@@ -12,48 +12,32 @@
   </div>
 </div>
 
-<div class="container">
+<div class="container highlight">
 
-<% if @highlight.photo.attached? %>
-  <p>
-    <%= image_tag @highlight.photo, class: "large" %>
-  </p>
-<% end %>
+      <div class="card ctaFirst">
+        <% if @highlight.photo.attached?  %>
+          <%= image_tag @highlight.photo.variant(resize: '360x360', gravity: 'center'), :class => "card-img-top", :alt => "alt text field needs to be added to model" %>
+        <% else %>
+          <%= image_tag "T.gif", style: 'width: 300px;' %>
+        <% end %>
+        <div class="card-body">
+            <%= link_to @highlight.link_label, strip_tags(@highlight.link) %>
+            <br /><br />
+          <span>Tags:</span> 
+            <% @highlight.tags.split(', ').each do |tag| %>
+                <%= tag %><% unless @highlight.tags.split(', ').last == tag %>, <% end %>
+            <% end %>
+          </div>
+        </div>
 
-<p>
-  <strong>Title:</strong>
-  <%= @highlight.title %>
-</p>
+        <div class="description">
 
+          <h3><%= @highlight.title %></h3>
 
-<p>
-  <strong>Blurb:</strong>
-  <%= @highlight.blurb %>
-</p>
+          <%= sanitize @highlight.blurb.html_safe %>
 
-<p>
-  <strong>Link:</strong>
-  <%= @highlight.link %>
-</p>
+        </div>
 
-<p>
-  <strong>Date:</strong>
-  <%= @highlight.date %>
-</p>
-
-<p>
-  <strong>Time:</strong>
-  <%= @highlight.time %>
-</p>
-
-<p>
-  <strong>Type:</strong>
-  <%= @highlight.type_of_highlight %>
-</p>
-
-<p>
-  <strong>Tags:</strong>
-  <%= @highlight.tags %>
-</p>
 
 </div>
+<div style="clear: both;"></div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -86,7 +86,7 @@
 				  <div class="card-body">
 				    <span class="card-title"><%= highlight.title %></span>
 				    <p class="card-text"><%= highlight.blurb %></p>
-				    <%= link_to "See more >", highlight.link, class: 'see-more' %>
+				    <%= link_to "See more >", highlight_path(highlight), class: 'see-more' %>
 				  </div>
 				</div>
 			</div>

--- a/db/migrate/20181205150746_remove_time_and_date_fields_from_highlights.rb
+++ b/db/migrate/20181205150746_remove_time_and_date_fields_from_highlights.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveTimeAndDateFieldsFromHighlights < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :highlights, :date, :date
+    remove_column :highlights, :time, :time
+    add_column :highlights, :link_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_190236) do
+ActiveRecord::Schema.define(version: 2018_12_05_173332) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -156,8 +156,6 @@ ActiveRecord::Schema.define(version: 2018_11_30_190236) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.string "phone_number"
-    t.string "email_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "group_type"
@@ -168,13 +166,12 @@ ActiveRecord::Schema.define(version: 2018_11_30_190236) do
     t.string "title"
     t.text "blurb"
     t.string "link"
-    t.date "date"
-    t.time "time"
     t.string "type_of_highlight"
     t.string "tags"
     t.boolean "promoted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "link_label"
   end
 
   create_table "library_hours", force: :cascade do |t|

--- a/spec/factories/highlights.rb
+++ b/spec/factories/highlights.rb
@@ -5,8 +5,6 @@ FactoryBot.define do
     title { "MyString" }
     blurb { "MyText" }
     link { "MyString" }
-    date { "2018-09-14" }
-    time { "2018-09-14 17:10:23" }
     type_of_highlight { "" }
     tags { "MyString" }
     photo { "photo" }

--- a/spec/views/highlights/show.html.erb_spec.rb
+++ b/spec/views/highlights/show.html.erb_spec.rb
@@ -14,12 +14,11 @@ RSpec.describe "highlights/show", type: :view do
     ))
   end
 
-  it "renders attributes in <p>" do
+  it "renders attributes in <div>" do
     render
     expect(rendered).to match(/Title/)
     expect(rendered).to match(/MyText/)
     expect(rendered).to match(/Link/)
-    expect(rendered).to match(/Type/)
     expect(rendered).to match(/Tags/)
   end
 end


### PR DESCRIPTION
#MAN-27

Create four news and highlights slots where Sara and Kaitlyn can manually add news and highlight items. There should be a link, an image and text. This is similar to the manual spots you created on the TUpress site.

These will likely need to be stored locally on the server, as opposed to being streamed in from WordPress, LibGuides, etc.

*****************

- Updated fields for highlights and adjusted show page to display on site rather redirect to external or other internal url.

- Cleaned up tests and rubocop