### PR TITLE
Enlarged font on button.

### DIFF
--- a/app/assets/stylesheets/persons.scss
+++ b/app/assets/stylesheets/persons.scss
@@ -92,3 +92,6 @@
   -moz-box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.6);
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.6);
 }
+.appointmentbutton.solo {
+	font-size: larger;
+}

--- a/app/views/persons/show.html.erb
+++ b/app/views/persons/show.html.erb
@@ -27,7 +27,7 @@
         <br /><br />
         <% unless @person.springshare_id.blank? %>
           <div class="appt_button">
-            <%= link_to "Make an Appointment", "https://api3.libcal.com/appointments-widget.php?u=#{@person.springshare_id}&iid=1621&t=Make%20an%20Appointment", class: "appointmentbutton", target: "_new" %>
+            <%= link_to "Make an Appointment", "https://api3.libcal.com/appointments-widget.php?u=#{@person.springshare_id}&iid=1621&t=Make%20an%20Appointment", class: "appointmentbutton solo", target: "_new" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
MAN-126 Enlarge_Schedule_an_appointment_button

On the person entity page, please make the "Schedule an appointment" button slightly larger and more prominent. Make the background red and the text white and slightly bolder.

Comments:

G. Christopher Doyle added a comment - 27/Nov/18 4:23 PM
Rachel and I had agreed to drop the red background as the button is not applied to each person on a page listing and the red really pulls the eye in different directions depending on which entries have the button or not, creating more of a jumbled display rather than a nice, neat and even display as seen with the toned down buttons. They could be a bit larger if necessary, but the change in color was purposeful.

Cynthia Schwarz added a comment - 1 week ago
I agree that this looks good when looking at a list of staff where some have the button and some don't. However, on the individual person entity page, the button needs to be more prominent.