### PR TITLE
Add workaround that prevents updating events

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,17 +2,26 @@
 
 module Admin
   class EventsController < Admin::ApplicationController
-    # [TODO] the Admin::SortByAttribute prevents database updates from the admin form
-    # include Admin::SortByAttribute
-    # # Override the default sort of id
-    # def sort_by
-    #   :start_time
-    # end
+    include Admin::SortByAttribute
+    # Override the default sort of id
+    def sort_by
+      :start_time
+    end
 
     def sync
       SyncService::Events.call()
       flash[:notice] = "Events synced"
       redirect_to admin_events_path
+    end
+
+  private
+
+    # Workaround that prevents updating event objects
+    def default_params
+      resource_params = params.fetch(resource_name, {})
+      order = resource_params.fetch(:order, "start_time")
+      direction = resource_params.fetch(:direction, "asc")
+      params[resource_name] = resource_params.merge(order: order, direction: direction)
     end
   end
 end


### PR DESCRIPTION
- Addresses Issue: MAN-130
- Cannot update events when we set sort ordering on start date when we
  pass the :order and :direction parameters.
- Solution Reference:
  [https://github.com/thoughtbot/administrate/issues/442#issuecomment-439209910]