### PR TITLE
Prevent word-breaks in donate button

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,9 +1,9 @@
 <div id="site-footer" class="">
   <div class="row social">
-    <div class="col-4">
+    <div class="col-7">
       <%= link_to "Donate to the Libraries", "#", class: 'donate' %>
     </div>
-    <div class="col-8 text-right">
+    <div class="col-5 text-right">
       <ul>
         <li class="social-footer instagram">
           <%= link_to image_tag('instagram-logo_white.svg'), 'http://instagram.com/tulibraries' %>


### PR DESCRIPTION
#MAN-140

Can you make the "Donate to the libraries" button span a wider area so that it doesn't wrap when you shrink the screen.
**********************************
Adjusted non-breaking of text in Donate link down to lowest supported resolution. It will line break if you reduce the browser width to below the smallest device size, but that will never happen on a device, and if a browser is that small the site is unusable anyway.