### PR TITLE
#MAN-152 updates to finish ticket

### DIFF
--- a/app/assets/stylesheets/services.scss
+++ b/app/assets/stylesheets/services.scss
@@ -70,6 +70,7 @@
 			max-height: 100%;
 			li {
 				padding: 0 14px 7px 14px;
+				white-space: normal;
 			}
 		}
 	}

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -8,7 +8,7 @@
 
 <div class="row ctaRow service-show">
   <% unless @related_services.blank? %>
-  <div class="col-3">
+  <div class="col-3 text-right">
     <div class="card ctaFirst">
       <div class="card-title">Related Services</div>
       <div class="card-body">
@@ -40,7 +40,7 @@
       <%= sanitize @service.service_policies.html_safe %>
     <% end %>
   </div>
-  <div class="col-3 text-right">
+  <div class="col-3 text-left">
     <div class="card ctaLast">
       <div class="card-title">
         Hours

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -158,6 +158,8 @@ ActiveRecord::Schema.define(version: 2019_01_03_221045) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "description"
+    t.string "phone_number"
+    t.string "email_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "group_type"

--- a/spec/views/persons/index.html.erb_spec.rb
+++ b/spec/views/persons/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "persons/index.html.erb", type: :view do
     @persons = [ ]
     render partial: "persons/alphamenu"
     render
-    expect(rendered).to match /persons/
+    expect(rendered).to match /Library Staff Directory/
   end
 
   it "displays the sample person name" do


### PR DESCRIPTION
Can you apply the maximum width to the service entity page, similar to what you did with the home page?

when I look at it on my screen, the white space is added between the columns, not on the edges
*****************************************
- Adjusted side boxes to float toward center, and allowed word wrap on bulleted items in related categories list.

- Updated test to check for new page title