### PR TITLE
#MAN-28 Entities Add To Footer Link

### DIFF
--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -9,7 +9,6 @@
 	padding-left: 3rem!important;
 	color: $light-grey!important;
 	line-height: 2em;
-		text-transform: uppercase;
 	h2 {
 		background-color: transparent!important;
 		border-left: 0;
@@ -20,7 +19,6 @@
 		color: $light-grey!important;
 		font-size: 125%;
 		letter-spacing: .15rem;
-		text-transform: uppercase;
 	}
 	a.col-heading {
 		color: $white!important;
@@ -30,6 +28,12 @@
 	}
 	ul {
 		margin-top: 1rem;
+		li {
+			line-height:1.2rem;
+			a{
+				font-size: 16px;
+			}
+		}
 	}
 }
 #footer-collections {
@@ -38,14 +42,20 @@
 #site-footer {
 		background-color: $footer-gray;
 	.postscript {
+		margin-bottom: 0;
 		.footer-col {
 			ul li {
 				letter-spacing: .1rem;
 			}
-			li.see-all {
-				font-style: italic;
-				font-size: 80%;
-			}
+		}
+	}
+	.see-all {
+		font-style: italic;
+		padding-top: 0;
+		margin-top: 0;
+		margin-bottom: 10px!important;
+		a {
+			font-size: 85%;
 		}
 	}
 	.footer-logo {
@@ -82,7 +92,7 @@
 	.postscript {
 		font-weight: normal;
 		padding-left: 30px;
-		margin:10px auto;
+		margin:0 auto 0 auto;
 		width:100%;
 		.region-postscript-first {
 			padding-left: 42px;
@@ -129,10 +139,8 @@
 				padding-right:28px;
 				font-size: 120%;
 				color: $light-grey;
-				text-transform: uppercase;
 				a {
 					color: $light-grey;
-					text-transform: uppercase;
 				}
 			}
 		}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   # user, we have no access to the devise object. So, we need to override
   # current_user to return the current account. This is needed both
   # in ApplicationController and in Admin::ApplicationController
-  before_action :get_alert
+  before_action :get_alert, :set_footer
 
   def current_user
     current_account
@@ -13,5 +13,12 @@ class ApplicationController < ActionController::Base
 
   def get_alert
     @alert = Alert.where(published: true)
+  end
+
+  def set_footer
+    @footer_buildings = Building.where(add_to_footer: true).take(6)
+    @footer_collections = Collection.where(add_to_footer: true).take(6)
+    @footer_services = Service.where(add_to_footer: true).take(6)
+    @footer_groups = Group.where(add_to_footer: true).take(6)
   end
 end

--- a/app/dashboards/building_dashboard.rb
+++ b/app/dashboards/building_dashboard.rb
@@ -22,6 +22,7 @@ class BuildingDashboard < BaseDashboard
     campus: Field::String,
     email: Field::Email,
     policies: Field::HasMany,
+    add_to_footer: Field::Boolean.with_options(admin_only: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -70,6 +71,7 @@ class BuildingDashboard < BaseDashboard
     :hours,
     :email,
     :policies,
+    :add_to_footer,
   ].freeze
 
   # Overwrite this method to customize how buildings are displayed

--- a/app/dashboards/collection_dashboard.rb
+++ b/app/dashboards/collection_dashboard.rb
@@ -16,6 +16,7 @@ class CollectionDashboard < Administrate::BaseDashboard
     subject: DescriptionField,
     contents: DescriptionField,
     building: Field::BelongsTo,
+    add_to_footer: Field::Boolean.with_options(admin_only: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -54,6 +55,7 @@ class CollectionDashboard < Administrate::BaseDashboard
     :subject,
     :contents,
     :building,
+    :add_to_footer,
   ].freeze
 
   # Overwrite this method to customize how collections are displayed

--- a/app/dashboards/group_dashboard.rb
+++ b/app/dashboards/group_dashboard.rb
@@ -24,6 +24,7 @@ class GroupDashboard < BaseDashboard
       collection: Rails.configuration.group_types
       ),
     policies: Field::HasMany,
+    add_to_footer: Field::Boolean.with_options(admin_only: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -65,6 +66,7 @@ class GroupDashboard < BaseDashboard
     :space,
     :documents,
     :policies,
+    :add_to_footer,
   ].freeze
 
   # Overwrite this method to customize how groups are displayed

--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -28,6 +28,7 @@ class ServiceDashboard < Administrate::BaseDashboard
     service_group: Field::HasMany,
     related_groups: Field::HasMany.with_options(class_name: "Group"),
     hours: Field::String,
+    add_to_footer: Field::Boolean.with_options(admin_only: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -67,7 +68,8 @@ class ServiceDashboard < Administrate::BaseDashboard
     :service_category,
     :related_spaces,
     :related_groups,
-    :hours
+    :hours,
+    :add_to_footer
   ].freeze
 
   def display_resource(service)

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -30,81 +30,80 @@
         <div class="col-md-6 col-lg-3 footer-col" id="footer-buildings">
           <h2><%= link_to "Libraries", buildings_path, class: "col-heading" %></h2>
           <ul>
-            <li>Library 1</li>
-            <li>Library 2</li>
-            <li>Library 3</li>
-            <li>Library 4</li>
-            <li>Library 5</li>
-            <li>Library 6</li>
-            <li class="see-all">View all Libraries</li>
+            <% @footer_buildings.each do |library| %>
+              <li><%= link_to library.name, library %></li>
+            <% end %>
             </ul>
         </div>
-        <div class="col-md-6 col-lg-3 footer-col" id="footer-spaces">
-          <h2><%= link_to "Spaces", spaces_path, class: "col-heading" %></h2>
+        <div class="col-md-6 col-lg-3 footer-col" id="footer-services">
+          <h2><%= link_to "Services", services_path, class: "col-heading" %></h2>
           <ul>
-            <li>Space 1</li>
-            <li>Space 2</li>
-            <li>Space 3</li>
-            <li>Space 4</li>
-            <li>Space 5</li>
-            <li>Space 6</li>
-            <li class="see-all">View all Spaces</li>
+            <% @footer_services.each do |service| %>
+              <li><%= link_to service.title, service %></li>
+            <% end %>
             </ul>
         </div>
         <div class="col-md-6 col-lg-3 footer-col" id="footer-groups">
           <h2><%= link_to "Groups", groups_path, class: "col-heading" %></h2>
           <ul>
-            <li>Group 1</li>
-            <li>Group 2</li>
-            <li>Group 3</li>
-            <li>Group 4</li>
-            <li>Group 5</li>
-            <li>Group 6</li>
-            <li class="see-all">View all Groups</li>
+            <% @footer_groups.each do |group| %>
+              <li><%= link_to group.name, group %></li>
+            <% end %>
             </ul>
         </div>
         <div class="col-md-6 col-lg-3 footer-col" id="footer-collections">
           <h2><%= link_to "Collections", collections_path, class: "col-heading" %></h2>
           <ul>
-            <li>Collection 1</li>
-            <li>Collection 2</li>
-            <li>Collection 3</li>
-            <li>Collection 4</li>
-            <li>Collection 5</li>
-            <li>Collection 6</li>
-            <li class="see-all">View all Collections</li>
+            <% @footer_collections.each do |collection| %>
+              <li><%= link_to collection.name, collection %></li>
+            <% end %>
             </ul>
         </div>
       </div>
 
+        <div class="postscript row see-all">
+          <div class="col-md-6 col-lg-3 footer-col">
+            <div><%= link_to "View all Libraries", buildings_path %></div>
+          </div>
+          <div class="col-md-6 col-lg-3 footer-col">
+            <div><%= link_to "View all Services", services_path %></div>
+          </div>
+          <div class="col-md-6 col-lg-3 footer-col">
+            <div><%= link_to "View all Groups", groups_path %></div>
+          </div>
+          <div class="col-md-6 col-lg-3 footer-col">
+            <div><%= link_to "View all Collections", collections_path %></div>
+          </div>
+      </div>
 
       <div class="tu-links">    
 
-        <div class="region region-footer">
+        <div class="region region-footer footer-col">
+          <h2 style="border-bottom: solid #ccc 1px;">Useful Links</h2>
 
-          <div class="row" style="margin-left: 7vw">
-            <div class="col-xs-5 offset-xs-7 col-sm-6 col-md-4 col-lg-2">
+          <div class="row">
+            <div class="col-md-6 col-lg-3 ">
               <ul>
                 <li>EZ-borrow</li>
                 <li>ILLiad</li>
                 <li>RefWorks</li>
               </ul>
             </div>
-            <div class="col-xs-5 offset-xs-7 col-sm-6 col-md-4 col-lg-2 offset-lg-1">
+            <div class="col-md-6 col-lg-3 ">
               <ul>
                 <li>Staff&nbsp;directory</li>
                 <li>Contact us</li>
                 <li>Memberships</li>
               </ul>
             </div>
-            <div class="col-xs-5 offset-xs-7 col-sm-6 col-md-4 col-lg-2 offset-lg-1">
+            <div class="col-md-6 col-lg-3 ">
               <ul>
                 <li>Jobs</li>
                 <li>Publications</li>
                 <li>Donate</li>
               </ul>
             </div>
-             <div class="col-xs-5 offset-xs-7 col-sm-6 col-md-4 col-lg-2 offset-lg-1">
+             <div class="col-md-6 col-lg-3 ">
               <ul>
                 <li>Policies</li>
               </ul>

--- a/db/migrate/20190109153034_add_footer_link_checkboxes.rb
+++ b/db/migrate/20190109153034_add_footer_link_checkboxes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddFooterLinkCheckboxes < ActiveRecord::Migration[5.2]
+  def up
+    add_column :buildings, :add_to_footer, :boolean
+    add_column :services, :add_to_footer, :boolean
+    add_column :groups, :add_to_footer, :boolean
+    add_column :collections, :add_to_footer, :boolean
+  end
+  def udown
+    add_column :buildings, :add_to_footer, :boolean
+    add_column :services, :add_to_footer, :boolean
+    add_column :groups, :add_to_footer, :boolean
+    add_column :collections, :add_to_footer, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_03_221045) do
+ActiveRecord::Schema.define(version: 2019_01_09_153034) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_221045) do
     t.datetime "updated_at", null: false
     t.string "google_id"
     t.string "address2"
+    t.boolean "add_to_footer"
   end
 
   create_table "collections", force: :cascade do |t|
@@ -112,6 +113,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_221045) do
     t.integer "building_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "add_to_footer"
     t.index ["building_id"], name: "index_collections_on_building_id"
   end
 
@@ -162,6 +164,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_221045) do
     t.datetime "updated_at", null: false
     t.string "group_type"
     t.boolean "external"
+    t.boolean "add_to_footer"
   end
 
   create_table "highlights", force: :cascade do |t|
@@ -275,6 +278,7 @@ ActiveRecord::Schema.define(version: 2019_01_03_221045) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "hours"
+    t.boolean "add_to_footer"
   end
 
   create_table "space_groups", force: :cascade do |t|

--- a/spec/views/persons/index.html.erb_spec.rb
+++ b/spec/views/persons/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "persons/index.html.erb", type: :view do
     @persons = [ ]
     render partial: "persons/alphamenu"
     render
-    expect(rendered).to match /persons/
+    expect(rendered).to match /Library Staff Directory/
   end
 
   it "displays the sample person name" do


### PR DESCRIPTION
#MAN-28

Add a field to the entity model for buildings, services, groups and collections labeled "Add to footer".

Field should be a check box.

Field is optional.

Field is an admin-only change.

The "Add to footer" checkbox will designate items that appear in the footer.

************************************

- Added add_to_footer checkbox to four footer models
- updated application controller and footer partial to only pull checked instances.
- rubocop, test fixes