### PR TITLE
#MAN-107 Added ability to display units for LRS department.

### DIFF
--- a/app/views/persons/index.html.erb
+++ b/app/views/persons/index.html.erb
@@ -47,7 +47,14 @@
     <div class="col-3">
       <% person.groups.each_with_index do |group, index| %>
         <% if group.group_type == "Department" %>
-          <%= group.name %><% unless index == (person.groups.size - 1) %>, <br /><% end %>
+          <%= group.name %><% if group.name == "Learning and Research Services" %>: 
+            <% person.groups.each do |unit| %>
+              <% if unit.group_type == "Departmental Unit" %>
+                <%= unit.name %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% unless index == (person.groups.size - 1) %> <br /><% end %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/persons/show.html.erb
+++ b/app/views/persons/show.html.erb
@@ -23,7 +23,18 @@
         <h1><%= @person.first_name %> <%= @person.last_name %></h1>
         <strong><%= @person.job_title %></strong><br />
         <% unless @person.groups.first.nil? %>
-          <%= @person.groups.first.name %>
+          <% @person.groups.each_with_index do |group, index| %>
+            <% if group.group_type == "Department" %>
+              <%= group.name %><% if group.name == "Learning and Research Services" %>: 
+                <% @person.groups.each do |unit| %>
+                  <% if unit.group_type == "Departmental Unit" %>
+                    <%= unit.name %>
+                  <% end %>
+                <% end %>
+              <% end %>
+              <% unless index == (@person.groups.size - 1) %> <br /><% end %>
+            <% end %>
+          <% end %>
         <% end %>
         <br /><br />
         <% unless @person.springshare_id.blank? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Tude
     config.group_types = ["Assembly",
                           "Committee",
                           "Department",
+                          "Departmental Unit",
                           "Functional Team",
                           "Strategic Steering Team",
                           "Working Group"]


### PR DESCRIPTION
#MAN-107

Create a new field for "home department". This field will be a related group and will be the person's home department. The "Groups" field will be used to list any other groups that this person belongs to that are secondary to their home department.

The contact information that displays on the person's page will be pulled from the 'Home department' related space information.

******************************

Added ability to display units for LRS department. Updated person index and show view templates to pull in the units and display if the dept is LRS. 
