### PR TITLE
#MAN-202 Remove space between entities

### DIFF
--- a/app/assets/stylesheets/buildings.scss
+++ b/app/assets/stylesheets/buildings.scss
@@ -22,7 +22,8 @@ div.required  label::after {
 		margin: auto;
 		background-color: $background-grey;
 		max-width:680px;
-		height:450px;
+		height: auto;
+		min-height:450px;
 		div.text {
 			padding:21px;
 			margin:auto;
@@ -77,7 +78,14 @@ div.required  label::after {
     overflow: hidden;
     padding: 0;
     width: 250px;
-    height: 190px;
+    height: 189px;
+    .lib-image {
+    	/*min-height:190px;*/
+    }
+    .default-image {
+    	width:190px;
+    	height:190px;
+    }
 	}
   .card-title {
   	font-size:125%;
@@ -95,11 +103,11 @@ div.required  label::after {
 		position: relative;
 		line-height: 3.0rem;
   	display: table;
-			a {
-				color: $white;
-			};
 		font-size: larger;
 		margin-bottom: 21px;
+		a {
+			color: $white;
+		}
 	}
 	.card-body {
     display: table-cell;

--- a/app/dashboards/group_dashboard.rb
+++ b/app/dashboards/group_dashboard.rb
@@ -25,6 +25,9 @@ class GroupDashboard < BaseDashboard
       ),
     policies: Field::HasMany,
     add_to_footer: Field::Boolean.with_options(admin_only: true),
+    parent_group: Field::HasOne.with_options(
+      class_name: "Group"
+      ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -60,6 +63,7 @@ class GroupDashboard < BaseDashboard
     :name,
     :description,
     :group_type,
+    :parent_group,
     :external,
     :chair_dept_heads,
     :persons,

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -4,6 +4,7 @@ class Building < ApplicationRecord
   include Validators
   include InputCleaner
   include HasPolicies
+  require "uploads"
 
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true
   validates :email, presence: true, email: true
@@ -19,6 +20,17 @@ class Building < ApplicationRecord
 
   before_validation :normalize_phone_number
   before_validation :sanitize_description
+
+  def index_image
+    variation =
+      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 250, height: 190, blob: photo.blob, gravity: "Center"))
+    ActiveStorage::Variant.new(photo.blob, variation)
+  end
+  def show_image
+    variation =
+      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 600, height: 450, blob: photo.blob, gravity: "Center"))
+    ActiveStorage::Variant.new(photo.blob, variation)
+  end
 
   def todays_hours
     @today = Date.today.strftime("%Y-%m-%d 00:00:00")

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,6 +12,8 @@ class Group < ApplicationRecord
 
   has_many_attached :documents, dependent: :destroy
 
+  has_one :parent_group, required: false, class_name: "Group"
+
   has_many :member
   has_many :persons, -> { order "last_name ASC" }, through: :member, source: :person
 

--- a/app/views/buildings/index.html.erb
+++ b/app/views/buildings/index.html.erb
@@ -18,12 +18,12 @@
 <% unless @buildings.nil? %>
 
     <% @buildings.each do |building| %>
-      <div class="col-12 col-sm-6 col-md-4 text-center" >
+      <div class="col-12 col-sm-6 col-lg-3 text-center" >
         <div class="card">
           <% if building.photo.attached? %>
-            <%= link_to image_tag(building.photo.variant(gravity: 'center', crop: "250x250+50%+30%", extent: "100%x100%"), class: "card-img-top", alt: "", style: "width:380px;max-height:190px"), building_path(building) %>
+            <%= link_to image_tag(building.index_image, class: "lib-image", alt: ""), building_path(building) %>
           <% else %>
-            <%= link_to image_tag('T-borderless.gif', class: "card-img-top", alt: "", style: "width:190px;height:190px"), building_path(building) %>
+            <%= link_to image_tag('T-borderless.gif', class: "default-image", alt: ""), building_path(building) %>
           <% end %>
         </div>
         <div class="card-body">

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -11,7 +11,7 @@
   <div class="col-lg-12 col-xl-6 text-center text-xl-right">
     <div class="building-image">
       <% if @building.photo.attached? %>
-        <%= image_tag @building.photo.variant(gravity: 'center', extent: "100%x100%") %>
+        <%= image_tag @building.show_image, alt: "" %>
       <% else %>
         <%= image_tag 'T-borderless.gif' %>
       <% end %>

--- a/lib/uploads.rb
+++ b/lib/uploads.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# lib/uploads.rb
+class Uploads
+  class << self
+    def jpeg?(blob)
+      blob.content_type.include? "jpeg"
+    end
+
+    def optimize
+      {
+        strip: true
+      }
+    end
+
+    def optimize_jpeg
+      {
+        strip: true,
+        'sampling-factor': "4:2:0",
+        quality: "85",
+        interlace: "JPEG",
+        colorspace: "sRGB"
+      }
+    end
+
+    def optimize_hash(blob)
+      return optimize_jpeg if jpeg? blob
+      optimize
+    end
+
+    def resize_to_limit(width:, height:, blob:)
+      {
+        resize: "#{width}x#{height}>"
+      }.merge(optimize_hash(blob))
+    end
+
+    def resize_to_fit(width:, height:, blob:)
+      {
+        resize: "#{width}x#{height}"
+      }.merge(optimize_hash(blob))
+    end
+
+    def resize_to_fill(width:, height:, blob:, gravity: "Center")
+      blob.analyze unless blob.analyzed?
+
+      cols = blob.metadata[:width].to_f
+      rows = blob.metadata[:height].to_f
+      if width != cols || height != rows
+        scale_x = width / cols
+        scale_y = height / rows
+        if scale_x >= scale_y
+          cols = (scale_x * (cols + 0.5)).round
+          resize = cols.to_s
+        else
+          rows = (scale_y * (rows + 0.5)).round
+          resize = "x#{rows}"
+        end
+      end
+
+      {
+        resize: resize,
+        gravity: gravity,
+        background: "rgba(255,255,255,0.0)",
+        extent: cols != width || rows != height ? "#{width}x#{height}" : ""
+      }.merge(optimize_hash(blob))
+    end
+
+    def resize_and_pad(width:, height:, blob:, background: :transparent, gravity: "Center")
+      {
+        thumbnail: "#{width}x#{height}>",
+        background: background == :transparent ? "rgba(255, 255, 255, 0.0)" : background,
+        gravity: gravity,
+        extent: "#{width}x#{height}"
+      }.merge(optimize_hash(blob))
+    end
+  end
+end


### PR DESCRIPTION
#MAN-202 
Similar to what we did on the main homepage, can you remove the space between the building entities on the index page and instead have more white space on the outside of the three columns.

*********************
- Changed rows of three to rows of four in order to minimize space betw…een images when window stretches.
- Also optimized calls to and display of images for index and show pages.