### PR TITLE
#MAN-107 Create a "home department" group in Person Entity

### DIFF
--- a/app/dashboards/group_dashboard.rb
+++ b/app/dashboards/group_dashboard.rb
@@ -25,8 +25,11 @@ class GroupDashboard < BaseDashboard
       ),
     policies: Field::HasMany,
     add_to_footer: Field::Boolean.with_options(admin_only: true),
-    parent_group: Field::BelongsTo,
-    child_groups: Field::HasMany,
+    parent_group: Field::BelongsTo.with_options(
+      class_name: "Group",
+      foreign_key: "parent_group_id",
+    ),
+    #child_groups: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -48,7 +51,7 @@ class GroupDashboard < BaseDashboard
     :description,
     :group_type,
     :parent_group,
-    :child_groups,
+    #:child_groups,
     :chair_dept_heads,
     :persons,
     :space,

--- a/app/dashboards/group_dashboard.rb
+++ b/app/dashboards/group_dashboard.rb
@@ -25,9 +25,8 @@ class GroupDashboard < BaseDashboard
       ),
     policies: Field::HasMany,
     add_to_footer: Field::Boolean.with_options(admin_only: true),
-    parent_group: Field::HasOne.with_options(
-      class_name: "Group"
-      ),
+    parent_group: Field::BelongsTo,
+    child_groups: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -48,6 +47,8 @@ class GroupDashboard < BaseDashboard
     :name,
     :description,
     :group_type,
+    :parent_group,
+    :child_groups,
     :chair_dept_heads,
     :persons,
     :space,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,7 +12,7 @@ class Group < ApplicationRecord
 
   has_many_attached :documents, dependent: :destroy
 
-  belongs_to :parent_group, ->(group) {  where.not(id: group.id) }, optional: true, class_name: "Group"
+  belongs_to :parent_group, optional: true, class_name: "Group"
   has_many :child_groups, class_name: "Group", foreign_key: "parent_group_id"
 
   has_many :member

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,7 +12,8 @@ class Group < ApplicationRecord
 
   has_many_attached :documents, dependent: :destroy
 
-  has_one :parent_group, required: false, class_name: "Group"
+  belongs_to :parent_group, ->(group) {  where.not(id: group.id) }, optional: true, class_name: "Group"
+  has_many :child_groups, class_name: "Group", foreign_key: "parent_group_id"
 
   has_many :member
   has_many :persons, -> { order "last_name ASC" }, through: :member, source: :person

--- a/db/migrate/20190128201026_add_parent_group_id_to_groups.rb
+++ b/db/migrate/20190128201026_add_parent_group_id_to_groups.rb
@@ -1,0 +1,5 @@
+class AddParentGroupIdToGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :groups, :parent_group
+  end
+end

--- a/db/migrate/20190128201026_add_parent_group_id_to_groups.rb
+++ b/db/migrate/20190128201026_add_parent_group_id_to_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddParentGroupIdToGroups < ActiveRecord::Migration[5.2]
   def change
     add_reference :groups, :parent_group

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_22_151522) do
-
+ActiveRecord::Schema.define(version: 2019_01_28_201026) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -184,6 +183,8 @@ ActiveRecord::Schema.define(version: 2019_01_22_151522) do
     t.string "group_type"
     t.boolean "external"
     t.boolean "add_to_footer"
+    t.integer "parent_group_id"
+    t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
   end
 
   create_table "highlights", force: :cascade do |t|

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -101,4 +101,22 @@ RSpec.describe Group, type: :model do
       expect(group.policies).to include(policy)
     end
   end
+
+  context "Parent Group and child groups" do
+    let(:group)  { FactoryBot.create(:group) }
+    let(:pgroup) { FactoryBot.create(:group) }
+    it "can have an associated parent_group" do
+      group.parent_group = pgroup
+      group.save
+      expect(group.parent_group).to be pgroup
+    end
+    it "displays associated child groups" do
+      another_child = FactoryBot.create(:group)
+      group.parent_group = pgroup
+      another_child.parent_group = pgroup
+      group.save
+      another_child.save
+      expect(pgroup.child_groups).to match_array([group, another_child])
+    end
+  end
 end


### PR DESCRIPTION
#MAN-107 Create a "home department" group in Person Entity

Create a new field for "home department". This field will be a related group and will be the person's home department. The "Groups" field will be used to list any other groups that this person belongs to that are secondary to their home department.

The contact information that displays on the person's page will be pulled from the 'Home department' related space information.

********************************************

Added the ability to add another group to a particular group, which would then be the parent group and the cild groups can be parsed out in the display(s).