### PR TITLE
#MAN-22 Hours and Email not marked as required in Building form, but are required by validations

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -7,7 +7,6 @@ class Building < ApplicationRecord
   require "uploads"
 
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true
-  validates :email, presence: true, email: true
   validates :phone_number, presence: true, phone_number: true
   validates :description, presence: true
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -9,8 +9,6 @@ class Space < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
 
-  validates :email, email: true
-  validates :phone_number, phone_number: true
   validates :building_id, presence: true
 
   before_validation :sanitize_description

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -27,25 +27,6 @@ RSpec.describe Building, type: :model do
 
     let(:building) { FactoryBot.build(:building) }
 
-    context "Email validation" do
-      example "valid email" do
-        building.email = "chas@example.edu"
-        expect { building.save! }.to_not raise_error
-      end
-      example "invalid email" do
-        building.email = "abc"
-        expect { building.save! }.to raise_error(/Email is not an email/)
-      end
-      example "strip email with trailing blank" do
-        building.email = "chas@example.edu "
-        expect { building.save! }.to_not raise_error
-      end
-      example "invalid email - blank " do
-        building.email = ""
-        expect { building.save! }.to raise_error(/Email can't be blank/)
-      end
-    end
-
     context "Phone number validation" do
       example "valid phone number" do
         building.phone_number = "2155551212"

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -47,36 +47,6 @@ RSpec.describe Space, type: :model do
 
     let (:space) { FactoryBot.build(:space) }
 
-    context "Email validation" do
-      example "valid email" do
-        space.email = "chas@example.edu"
-        expect { space.save! }.to_not raise_error
-      end
-      example "invalid email" do
-        space.email = "abc"
-        expect { space.save! }.to raise_error(/Email is not an email/)
-      end
-      example "invalid email - blank " do
-        space.email = ""
-        expect { space.save! }.to raise_error(/#{ I18n.t('manifold.error.invalid_email') }/)
-      end
-    end
-
-    context "Phone number validation" do
-      example "valid phone number" do
-        space.phone_number = "2155551212"
-        expect { space.save! }.to_not raise_error
-      end
-      example "invalid phone number" do
-        space.phone_number = "215555122"
-        expect { space.save! }.to raise_error(/#{I18n.t('manifold.error.invalid_phone_format')}/)
-      end
-      example "invalid phone number - blank " do
-        space.phone_number = ""
-        expect { space.save! }.to raise_error(/#{I18n.t('manifold.error.invalid_phone_format')}/)
-      end
-    end
-
     context "Building reference" do
       example "valid building" do
         expect { space.save! }.to_not raise_error


### PR DESCRIPTION
#MAN-22 
The building model validates the presence of Email and Hours, but the Dashboard form does not indicate they should are required with an asterisk.

Space entity requiring email and phone for validation, even though these fields are optional.

******************************************

Removed Email from Building required status. Hours must have been previously removed.
Removed validations for optional email and phone in Spaces