### PR TITLE
#MAN-208 Code event/exhibit index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "popper_js", "~> 1.14.5"
 gem "tinymce-rails", "~> 4.9"
 gem "google-api-client", "~> 0.28"
 gem "fuzzy_match"
+gem "kaminari"
 # Use jquery as the JavaScript library
 gem "jquery-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,7 @@ DEPENDENCIES
   jquery-rails
   json-ld
   json-schema
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mail_form
   mini_magick (~> 4.9)

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -94,20 +94,28 @@
 	.event {
 		border-bottom: solid $lightest-grey 2px;
 		margin-bottom: 14px;
+		img {
+			min-width: 150px;
+		}
 	}
 }
-	.exhibits-header {
-		margin-left: 14px;
-		padding-right: 14px;
-		background-color: $lightest-grey;
-		padding: 10px 21px;
-		color: $seagreen-on-grey;
-		font-size:150%;
-		margin-bottom: 35px;
+.event-show {
+	img {
+		min-width: 300px;
 	}
-	.paginator {
-		background-color: $lightest-grey;
-	}
+}
+.exhibits-header {
+	margin-left: 14px;
+	padding-right: 14px;
+	background-color: $lightest-grey;
+	padding: 10px 21px;
+	color: $seagreen-on-grey;
+	font-size:150%;
+	margin-bottom: 35px;
+}
+.paginator {
+	background-color: $lightest-grey;
+}
 .event_type {
 	background-color: $foamgreen!important;
 	text-align: center;

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -75,58 +75,142 @@
 
 
 /* END HOMEPAGE */
-.endcap {
-	h2 {
-		border-left: 0;
-		padding-left: 21px;
-		margin-top: 0;
+
+.events {
+	h3 {
+		a {
+			color: $black;
+			font-weight: 600;
+			text-decoration: underline;
+		}
+	}
+	.upcoming-header {
+		background-color:$footer-gray;
+		padding: 10px 21px;
+		color: $white;
+		font-size:150%;
+		margin-bottom: 35px;
+	}
+	.event {
+		border-bottom: solid $lightest-grey 2px;
 		margin-bottom: 14px;
 	}
-	p {
-		font-size: large;
-		padding-left: 21px;
+}
+	.exhibits-header {
+		margin-left: 14px;
+		padding-right: 14px;
+		background-color: $lightest-grey;
+		padding: 10px 21px;
+		color: $seagreen-on-grey;
+		font-size:150%;
+		margin-bottom: 35px;
 	}
-	padding: 0;
-	width: 90%;
-	overflow: hidden;
-	margin-bottom: 21px;
-	border-top-right-radius: 14px;
-	border-bottom-right-radius: 14px;
+	.paginator {
+		background-color: $lightest-grey;
+	}
+.event_type {
+	background-color: $foamgreen!important;
+	text-align: center;
+	padding: 4px 7px;
+	border: solid $foamgreen-complement 1px;
+	border-radius: 7px;
+	font-size: 90%;
+	color: $white!important;
+}
+.event_location {
+	background-color: $seagreen!important;
+	text-align: center;
+	padding: 4px 7px;
+	border: solid $seagreen-complement 1px;
+	border-radius: 7px;
+	font-size: 90%;
+	color: $white!important;
+}
+.exhibits {
+	.exhibit {
+		.exhibit_title {
+			font-size: 125%;
+			font-weight: 600;
+			color: $black;
+			text-decoration: underline;
+		}
+		.exhibit_title:hover {
+			color: $red;
+		}
+		border: solid $seagreen 1px;
+		border-radius: 7px;
+		background-color: transparent;
+		padding: 21px;
+		margin-bottom: 14px;
+	}
+	.location {
+		font-weight: 600;
+		color: $black;
+	}
+	.past-events-button, .video-button {
+		background-color: $seagreen;
+		padding: 21px;
+		color: $white;
+		font-size: 150%;
+		text-align: center;
+		border-radius: 7px;
+		display: inline-block;
+		width: 100%;
+		margin-left: 14px;
+		margin-bottom: 14px;
+	}
+	.video-button {
+		background-color: $foamgreen;
+	}
 }
 
-.purple {
-	h2 {
-		background-color: $purple-complement!important;
+.events_facets {
+	background-color: #eee;
+	padding-bottom: 21px;
+	padding-top: 21px;
+	input {
+		border-radius: 7px;
+		border-color: $footer-grey
 	}
-	border: solid $purple 2px;
-}
-.green {
-	h2 {
-		background-color: $seagreen-complement!important;
-		margin-bottom: 0;
+	a.reset {
+		display: block;
+		margin-top: 14px;
+		color: $black;
+	}
+	.events_search {
+		padding-left: 42px;
+	}
+	.fa.fa-search {
+		position: absolute;
+    top: 32px;
+    left: 42px;
+    font-size: 1.25rem;
+    color: #ccc;
+	}
+	ul {
+		margin-left: 7px;
 		a {
 			color: $black;
+			/*text-decoration: underline;*/
 		}
 	}
-	h2.event-space {
-		text-align: center;
-		padding: 21px 0;
+	.types_header {
+		margin-top: 28px;
+		color: #5B7335;
+		font-weight: 600;
 	}
-	border: solid $seagreen 2px;
+	.spaces_header {
+		color: #187768;
+		font-weight: 600;
+	}
+	.event_types, .event_spaces {
+		.active {
+			font-weight: bold;
+			padding: 4px;
+			padding-left: 10px;
+			margin-left: -10px;
+			background-color: $seagreen-complement;
+		}
+	}
 
-}
-.olive {
-	h2 {
-		background-color: $baby-puke-green!important;
-		margin-bottom: 0;
-		text-align: center;
-		padding-top: 21px;
-		padding-bottom: 21px;
-		border: solid $seagreen 2px;
-		border-top-right-radius: 14px;
-		border-bottom-right-radius: 14px;
-		a {
-			color: $black;
-		}
-	}
 }

--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -1,0 +1,143 @@
+@import "partials/_vars.scss";
+
+.pagination {
+	display: block!important;
+	margin-bottom: 21px;
+  a {
+    color: $black!important;
+  }
+  .page.current {
+    color: $seagreen;
+  }
+}
+.digg_pagination {
+  background: white;
+  cursor: default;
+  a, span, em {
+    padding: 0.2em 0.5em;
+    display: block;
+    float: left;
+    margin-right: 1px;
+  }
+  .disabled {
+    color: #999999;
+    border: 1px solid #dddddd;
+  }
+  .current {
+    font-style: normal;
+    font-weight: bold;
+    background: #2e6ab1;
+    color: white;
+    border: 1px solid #2e6ab1;
+  }
+  a {
+    text-decoration: none;
+    color: #105cb6;
+    border: 1px solid #9aafe5;
+    &:hover, &:focus {
+      color: #000033;
+      border-color: #000033;
+    }
+  }
+  .page_info {
+    background: #2e6ab1;
+    color: white;
+    padding: 0.4em 0.6em;
+    width: 22em;
+    margin-bottom: 0.3em;
+    text-align: center;
+    b {
+      color: #000033;
+      background: #2e6ab1 + 60;
+      padding: 0.1em 0.25em;
+    }
+  }
+  &:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
+  }
+  * html & {
+    height: 1%;
+  }
+  *:first-child+html & {
+    overflow: hidden;
+  }
+}
+.apple_pagination {
+  background: #f1f1f1;
+  border: 1px solid #e5e5e5;
+  text-align: center;
+  padding: 1em;
+  cursor: default;
+  li {
+  	margin: .67rem;
+  }
+  a, span {
+    padding: 0.2em 0.3em;
+  }
+  .disabled {
+    color: #aaaaaa;
+  }
+  .current {
+    font-style: normal;
+    font-weight: bold;
+    background-color: darken(#f1f1f1, 20);
+    display: inline-block;
+    width: 1.4em;
+    height: 1.4em;
+    line-height: 1.5;
+    -moz-border-radius: 1em;
+    -webkit-border-radius: 1em;
+    border-radius: 1em;
+    text-shadow: rgba(white, .8) 1px 1px 1px;
+  }
+  a {
+    text-decoration: none;
+    color: black;
+    &:hover, &:focus {
+      text-decoration: underline;
+    }
+  }
+}
+.flickr_pagination {
+  text-align: center;
+  padding: 0.3em;
+  cursor: default;
+  a, span, em {
+    padding: 0.2em 0.5em;
+  }
+  .disabled {
+    color: #aaaaaa;
+  }
+  .current {
+    font-style: normal;
+    font-weight: bold;
+    color: #ff0084;
+  }
+  a {
+    border: 1px solid #dddddd;
+    color: #0063dc;
+    text-decoration: none;
+    &:hover, &:focus {
+      border-color: #003366;
+      background: #0063dc;
+      color: white;
+    }
+  }
+  .page_info {
+    color: #aaaaaa;
+    padding-top: 0.8em;
+  }
+  .previous_page, .next_page {
+    border-width: 2px;
+  }
+  .previous_page {
+    margin-right: 1em;
+  }
+  .next_page {
+    margin-left: 1em;
+  }
+}

--- a/app/assets/stylesheets/partials/_vars.scss
+++ b/app/assets/stylesheets/partials/_vars.scss
@@ -15,6 +15,7 @@ $footer-grey: #a3a3a3;
 $green: #E5FFE5;
 $seagreen: #1f9584;
 $seagreen-complement: #c7e5e0;
+$seagreen-on-grey: #1f9584;
 $foamgreen: #82A14A;
 $foamgreen-complement: #dde3c5;
 $purple: #9a2e8c;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,18 +3,68 @@
 class EventsController < ApplicationController
   before_action :set_event, only: [:show]
 
-  # GET /events
-  # GET /events.json
   def index
-    @events = Event.all
+    @all_events = Event.group(:id)
+    @exhibitions = Exhibition.where(promoted_to_events: true)
+    @today = Date.today
+
+    unless params[:id] == "past"
+      @events = @all_events.having("start_time >= ?", @today).order(:start_time)
+      @event_types = return_types(@events)
+      @event_spaces = return_locations(@events)
+      @events = return_events(@events)
+    else
+      @events = @all_events.having("start_time < ?", @today).order(start_time: :desc)
+      @event_types = return_types(@events)
+      @event_spaces = return_locations(@events)
+      @events = return_events(@events)
+    end
+    
     respond_to do |format|
       format.html
-      format.json { render json: EventSerializer.new(@events) }
+      format.json { render json: EventSerializer.new(@event) }
     end
   end
 
-  # GET /events/1
-  # GET /events/1.json
+  def return_events(events)
+    if params.has_key?("type")
+      @events = @events.having("event_type LIKE ?", "%#{params[:type]}%").order(:start_time)
+    elsif params.has_key?("location")
+      @events = @events.having("external_space LIKE ?", "%#{params[:location]}%").or(@events.having("external_space LIKE ?", "%#{params[:location]}%")).order(start_time: :desc)
+    end
+    @events_list = @events.page params[:page]
+  end
+
+  def return_types(events)
+    @event_types = @events.pluck(:event_type)
+    @types = []
+    @event_types.each do |type|
+      types = type.split(",")
+      types.each do |t|
+        unless t.nil?
+          @types.push(t)
+        end
+      end
+    end
+    @event_types = @types.collect(&:strip).flatten.uniq.sort
+  end
+
+  def return_locations(events)
+    @event_spaces = @events.pluck(:space, :external_space).flatten
+    @spaces = []
+    @event_spaces.each do |space|
+      unless space.nil?
+        spaces = space.split(",")
+        spaces.each do |t|
+          unless t.nil? || t == "space" || t == "external_space" || t == I18n.t("manifold.default.event.space")
+            @spaces.push(t)
+          end
+        end
+      end
+    end
+    @event_spaces = @spaces.collect(&:strip).flatten.uniq.sort
+  end
+
   def show
     respond_to do |format|
       format.html
@@ -23,13 +73,7 @@ class EventsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_event
       @event = Event.find(params[:id])
-    end
-
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def event_params
-      params.require(:event).permit()
     end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,10 +19,9 @@ class EventsController < ApplicationController
       @event_spaces = return_locations(@events)
       @events = return_events(@events)
     end
-    
     respond_to do |format|
       format.html
-      format.json { render json: EventSerializer.new(@event) }
+      format.json { render json: EventSerializer.new(@events) }
     end
   end
 

--- a/app/dashboards/event_dashboard.rb
+++ b/app/dashboards/event_dashboard.rb
@@ -17,6 +17,7 @@ class EventDashboard < BaseDashboard
     title: Field::String,
     description: DescriptionField,
     tags: Field::String,
+    event_type: Field::String,
     start_time: Field::DateTime.with_options(format: "%D - %I:%M %p"),
     end_time: Field::DateTime.with_options(format: "%D - %I:%M %p"),
     all_day: Field::Boolean,
@@ -47,6 +48,7 @@ class EventDashboard < BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
     :title,
+    :event_type,
     :start_time,
     :end_time,
   ].freeze
@@ -57,6 +59,7 @@ class EventDashboard < BaseDashboard
     :id,
     :title,
     :description,
+    :event_type,
     :tags,
     :start_time,
     :end_time,
@@ -92,6 +95,7 @@ class EventDashboard < BaseDashboard
     :image,
     :alt_text,
     :description,
+    :event_type,
     :tags,
     :start_time,
     :end_time,

--- a/app/dashboards/exhibition_dashboard.rb
+++ b/app/dashboards/exhibition_dashboard.rb
@@ -11,7 +11,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     group: Field::BelongsTo,
-    space: Field::BelongsTo,
+    space: Field::BelongsTo.with_options(required: true),
     collection: Field::BelongsTo,
     photo: PhotoField,
     id: Field::Number,
@@ -19,6 +19,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
     description: Field::Text,
     start_date: Field::DateTime,
     end_date: Field::DateTime,
+    promoted_to_events: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -29,9 +30,9 @@ class ExhibitionDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :group,
-    :space,
+    :title,
     :collection,
+    :space,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -56,6 +57,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
     :description,
     :start_date,
     :end_date,
+    :promoted_to_events,
     :group,
     :space,
     :collection,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -39,15 +39,14 @@ class Event < ApplicationRecord
   end
 
   def index_image
-    image.variant(centered_image_variation).processed
-  end
-  
-  def show_image
-    image.variant(centered_image_variation).processed
+    image.variant(centered_image_variation(220, 220)).processed
   end
 
-  def centered_image_variation
-    ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
-    
+  def show_image
+    image.variant(centered_image_variation(300, 300)).processed
+  end
+
+  def centered_image_variation(width, height)
+    ActiveStorage::Variation.new(Uploads.resize_to_fill(width: width, height: height, blob: image.blob, gravity: "Center"))
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,12 +3,22 @@
 class Event < ApplicationRecord
   has_paper_trail
   include InputCleaner
+  paginates_per 5
   belongs_to :building, optional: true
   belongs_to :space, optional: true
   belongs_to :person, optional: true
   has_one_attached :image, dependent: :destroy
 
   before_save :sanitize_description
+
+  serialize :tags
+
+  def get_tags
+    self.tags.split(",").collect(&:strip)
+  end
+  def get_types
+    self.event_type.split(",").collect(&:strip)
+  end
 
   def can_visit
     unless building.nil?
@@ -26,5 +36,16 @@ class Event < ApplicationRecord
     else
       "All Day"
     end
+  end
+
+  def index_image
+    variation =
+      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
+    ActiveStorage::Variant.new(image.blob, variation)
+  end
+  def show_image
+    variation =
+      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
+    ActiveStorage::Variant.new(image.blob, variation)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -39,13 +39,15 @@ class Event < ApplicationRecord
   end
 
   def index_image
-    variation =
-      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
-    ActiveStorage::Variant.new(image.blob, variation)
+    image.variant(centered_image_variation).processed
   end
+  
   def show_image
-    variation =
-      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
-    ActiveStorage::Variant.new(image.blob, variation)
+    image.variant(centered_image_variation).processed
+  end
+
+  def centered_image_variation
+    ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 220, height: 220, blob: image.blob, gravity: "Center"))
+    
   end
 end

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -31,6 +31,7 @@ class SyncService::Events
       "title" => event.fetch("Title", I18n.t("manifold.default.event.title")),
       "description" => event.fetch("Description",  I18n.t("manifold.default.event.description")),
       "tags" => event.fetch("Tags", nil),
+      "event_type" => event.fetch("Type", nil),
       "cancelled" => event.fetch("Canceled", 0),
       "registration_status" => event.fetch("RegistrationStatus", I18n.t("manifold.default.event.registration_status")),
       "registration_link" => event.fetch("RegistrationLink", nil),
@@ -56,6 +57,7 @@ class SyncService::Events
       event.person = record_hash["person"]
       event.building = record_hash["building"]
       event.tags = record_hash["tags"]
+      event.event_type = record_hash["event_type"]
       unless (record_hash[:image].nil? || event.image.attached?)
         event.image.attach(
           io: record_hash[:image][:io],

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,0 +1,37 @@
+<% @events_list.each do |event| %>
+  <div class="row event">
+    <div class="col-3">
+    <% if event.image.attached? %>
+      <%= link_to (image_tag event.index_image), event %>
+    <% else %>
+      <%= image_tag 'T-borderless.gif' %>
+    <% end %>
+    </div>
+    <div class="col-9">
+      <h3><%= link_to event.title, event %></h3>
+      <p><strong>
+        <%= event.start_time.strftime("%^A, %^B %d, %Y ").titleize %> | 
+        <%= event.start_time.strftime("%l:00 %P") %> | 
+        <% unless event.space.nil? %>
+          int: <%= event.space.building.name %>
+        <% else %>
+          ext: <%= event.external_space %>
+        <% end %>
+      </strong></p>
+      <p><%= sanitize strip_tags(event.description.html_safe.truncate(250)) %></p>
+      <p>
+        <% unless event.get_types.nil? %>
+          <% event.get_types.each do |type| %>
+            <%= link_to type, event, class: "event_type" %> 
+          <% end %>
+        <% end %>
+
+        <% unless event.space.nil? %>
+          <%= link_to event.space.building.name, event.space.building, class: "event_location" %>
+        <% else %>
+          <span class="event_location"><%= event.external_space %></span> 
+        <% end %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/events/_exhibitions.html.erb
+++ b/app/views/events/_exhibitions.html.erb
@@ -1,0 +1,10 @@
+<% @exhibitions.each do |exhibit| %>
+<div class="row">
+  <div class="col-11 offset-1 exhibit">
+    <%= link_to exhibit.title, exhibit, class: "exhibit_title" %><br />
+    <%= exhibit.start_date.strftime("%^B %Y").titleize %> -  
+    <%= exhibit.end_date.strftime("%^B %Y").titleize %><br />
+    <%= link_to exhibit.space.name, exhibit.space, class: "location" %>
+  </div>
+</div>
+<% end %>

--- a/app/views/events/_facets.html.erb
+++ b/app/views/events/_facets.html.erb
@@ -1,0 +1,35 @@
+<div class="container events_facets">
+  <form action="https://librarysearch.temple.edu/bento">
+    <span class="fa fa-search"></span>
+    <input type="text" name="q" class="events_search" placeholder="Search events" />
+  </form>
+  <div class="event_types">
+    <h3 class="types_header">Event type</h3>
+    <ul class="unstyled">
+      <% @event_types.each do |type| %>
+        <% unless type == params[:type] %>
+          <li><%= link_to type, {controller: :events, action: :index, type: type} %></li>
+        <% else %>
+          <li class="active"><%= link_to type, {controller: :events, action: :index, type: type} %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+  <div class="event_spaces">
+    <h3 class="spaces_header">Location</h3>
+    <ul class="unstyled">
+      <% @event_spaces.each do |space| %>
+        <% unless space == params[:location] %>
+          <li><%= link_to space, {controller: :events, action: :index, location: space} %></li>
+        <% else %>
+          <li class="active"><%= link_to space, {controller: :events, action: :index, location: space} %></li>
+        <% end %>
+      <% end %>
+    </ul>
+  </div>
+  <div class="row">
+    <div class="col text-center">
+      <%= link_to "[ reset all filters ]", events_path, class: "reset" %>
+    </div>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,46 +1,63 @@
 <div class="row">
   <div class="col breadcrumbs">
     <%= link_to "Home", root_path.to_s %> 
-    Events
+    Events &amp; Exhibits
   </div>
 </div>
-<div class="row">
-  <div class="col">
-    <div class="vertical-stripes-sm">
-      <h2><span>Events</span></h2>
+
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <h1>Events &amp; Exhibits</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-3 filters">
+      <%= render "facets" %>"
+    </div>
+    <div class="col-6 events">
+      <div class="row">
+        <div class="col-12 upcoming-header">
+          <% unless params[:id] == "past" %>
+            Upcoming Events
+          <% else %>
+            Past Events
+          <% end %>
+        </div>
+      </div>
+      
+      <%= render "events" %>
+
+      <div class="row text-center paginator">
+        <div class="col">
+          <%= paginate @events_list %>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 exhibits">
+      <div class="row">
+        <div class="col-12 exhibits-header">
+          Current Exhibits
+        </div>
+      </div>
+
+      <%= render "exhibitions" %>
+
+      <div class="row">
+        <div class="col-12">
+          <% unless params[:id] == "past" %>
+            <%= link_to "View past events & exhibits", events_path(id: "past"), class: "past-events-button" %>
+          <% else %>
+            <%= link_to "View current events & exhibits", events_path, class: "past-events-button" %>
+          <% end %>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12">
+          <%= link_to "View video recordings from past events", events_path, class: "video-button" %>
+        </div>
+      </div>
     </div>
   </div>
 </div>
-
-<table>
-  <thead>
-    <tr>
-      <th>Title</th>
-      <th>Start time</th>
-      <th>End time</th>
-      <th>Library</th>
-      <th>Space</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @events.each do |event| %>
-      <tr>
-        <td><%= event.title %></td>
-        <td><%= event.start_time %></td>
-        <td><%= event.end_time %></td>
-        <% unless event.building.nil? %>
-          <td><%= event.building.name %></td>
-          <td><%= event.space.name unless event.space.nil? %></td>
-        <% else %>
-          <td><%= event.external_building %></td>
-          <td><%= event.external_space %></td>
-        <% end %>
-        <td><%= link_to 'Show', event %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<br>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :body_class, "event-show" %>
 <script type="application/ld+json">
   <%= json_ld(@event) %>
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
   resources :buildings, only: [:index, :show], path: "libraries"
   resources :groups, only: [:index, :show]
   resources :collections, only: [:index, :show]
-  resources :events, only: [:index, :show], path: "/beyondthepage"
+  resources :events, only: [:index, :show]
   resources :services, only: [:index, :show]
   resources :policies, only: [:index, :show]
   resources :exhibitions, only: [:index, :show]
@@ -67,6 +67,10 @@ Rails.application.routes.draw do
   #
   # If a finding aid can belong to multiple collections, we can't
   # determine which collection to display as the parent collection
+
+  controller :events do
+    get "events/past" => :index
+  end
 
 
   controller :pages do

--- a/db/migrate/20190207145221_add_fields_to_events.rb
+++ b/db/migrate/20190207145221_add_fields_to_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFieldsToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :event_type, :string
+    add_column :exhibitions, :promoted_to_events, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,8 +182,8 @@ ActiveRecord::Schema.define(version: 2019_03_21_175032) do
     t.integer "person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["finding_aid_id"], name: "index_finding_aid_responsibility_on_finding_aid_id"
-    t.index ["person_id"], name: "index_finding_aid_responsibility_on_person_id"
+    t.index ["finding_aid_id"], name: "index_finding_aid_responsibilities_on_finding_aid_id"
+    t.index ["person_id"], name: "index_finding_aid_responsibilities_on_person_id"
   end
 
   create_table "finding_aids", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(version: 2019_03_21_175032) do
     t.string "ensemble_identifier"
     t.text "tags"
     t.boolean "all_day", default: false
+    t.string "event_type"
     t.index ["building_id"], name: "index_events_on_building_id"
     t.index ["person_id"], name: "index_events_on_person_id"
     t.index ["space_id"], name: "index_events_on_space_id"
@@ -170,6 +171,7 @@ ActiveRecord::Schema.define(version: 2019_03_21_175032) do
     t.integer "collection_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "promoted_to_events"
     t.index ["collection_id"], name: "index_exhibitions_on_collection_id"
     t.index ["group_id"], name: "index_exhibitions_on_group_id"
     t.index ["space_id"], name: "index_exhibitions_on_space_id"
@@ -180,8 +182,8 @@ ActiveRecord::Schema.define(version: 2019_03_21_175032) do
     t.integer "person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["finding_aid_id"], name: "index_finding_aid_responsibilities_on_finding_aid_id"
-    t.index ["person_id"], name: "index_finding_aid_responsibilities_on_person_id"
+    t.index ["finding_aid_id"], name: "index_finding_aid_responsibility_on_finding_aid_id"
+    t.index ["person_id"], name: "index_finding_aid_responsibility_on_person_id"
   end
 
   create_table "finding_aids", force: :cascade do |t|

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     trait :with_image do
       after :create do |event|
         file_path = Rails.root.join("spec", "fixtures", "charles.jpg")
-        file = fixture_file_upload(file_path, "image/png")
+        file = fixture_file_upload(file_path, "image/jpeg")
         event.image.attach(file)
       end
     end


### PR DESCRIPTION
#MAN-208

This design was reviewed with communications staff and agreed upon

***************************************

Add Kaminari for pagination (chose this gem for compatibility with Administrate)
Add event_type field to model since tags is not where Event Type comes from in the xml feed
Update event sync service to pull type field and map to event_type
Add promoted to events checkbox to exhibition model to pull only those approved to the events page
Serialized tags and types with methods in model
Added methods to model to call image variants from view
Updated routes to remove beyondthepage reference and revert 
