### PR TITLE
#MAN-216 View All services link in the footer

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -36,7 +36,7 @@
             </ul>
         </div>
         <div class="col-md-6 col-lg-3 footer-col" id="footer-services">
-          <h2><%= link_to "Services", services_path, class: "col-heading" %></h2>
+          <h2><%= link_to "Services", service_path(2), class: "col-heading" %></h2>
           <ul>
             <% @footer_services.each do |service| %>
               <li><%= link_to service.title, service %></li>


### PR DESCRIPTION
#MAN-216

Since we don't have a separate services index page, the "view all service" link in the footer doesn't have anywhere to go. Can you please make this link go to .../services/2

*********************************

Updated link