### PR TITLE
#MAN-209 Add lists and tables to Tinymce editors

### DIFF
--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -3,3 +3,6 @@ toolbar:
 plugins:
   - image
   - link
+  - table
+  - lists
+  - advlist


### PR DESCRIPTION
#MAN-209 Add lists and tables to Tinymce editors

We need a way to create bulleted/numbered lists and tables. This is a big one – a lot of the content we've been working on contains lists and tabular data. In the writing for the web workshop, creating lists was one strategy I suggested for keeping content succinct and making it easy for users to scan the page. Tables are important for things like borrowing rules. I realize we don't want people using tables to format content on the page, but we can deal with that by... telling them not to.

**************************

Enabled lists and tables in Tinymce