### PR TITLE
#MAN-222 Tables not displaying

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,11 @@ module Tude
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.tinymce.install
+    config.action_view.sanitized_allowed_tags = ["div", "p", "h1", "h2", "h3", "h4", "h5", "h6",
+        "ul", "ol", "li", "dl", "dt", "dd", "address", "hr", "pre", "blockquote", "center",
+        "a", "span", "bdo", "br", "em", "strong", "dfn", "code", "samp", "cite", "basefont",
+        "font", "object", "param", "img", "table", "caption", "colgroup", "col", "thead", "tfoot", "tbody",
+        "tr", "th", "td", "embed"]
 
     config.generators do |g|
       g.test_framework :rspec, spec: true

--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -1,8 +1,9 @@
 toolbar:
-  - styleselect | bold italic | undo redo | image link
+  - styleselect | bold italic | undo redo | image link | code
 plugins:
   - image
   - link
   - table
   - lists
   - advlist
+  - code


### PR DESCRIPTION
#MAN-222

I am using the Insert -> table feature in the tinymce editor in the services entity. When I go to the view page, the table does not render as a table.

*****************
This only happened on Description fields. Description fields are being sanitized in the model and this was stripping out some html tags, so I had to specify all allowed tags in config and tables now show up.

Add allowed html tags to config.
Add code button to tinymce editor