### PR TITLE
Use env var for FQDN in production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,4 +71,4 @@ Rails.application.configure do
   }
 end
 
-Rails.application.routes.default_url_options[:host] = "test.host"
+Rails.application.routes.default_url_options[:host] = "localhost:3000"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,7 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
+
+  Rails.application.routes.default_url_options[:host] = ENV["MANIFOLD_FQDN"]
+
 end


### PR DESCRIPTION
Rails needs to know the fqdn to set a root_url, so we need to set that in a config via an env variable.