### PR TITLE
Use Bundler 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,4 +569,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   2.0.1


### PR DESCRIPTION
Bundler 2.0 is now the default when ruby 2.5.1 is installed. This upgrades ugrade to Bundler 2.0.

@skng5 and @cdoyle-temple This will requre you to manually reinstall bundler to get bundler 2.0 on your local environments. 