### PR TITLE
#MAN-246 Remove translation defaults on events sync service

### DIFF
--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -28,12 +28,12 @@ class SyncService::Events
 
   def record_hash(event)
     {
-      "title" => event.fetch("Title", I18n.t("manifold.default.event.title")),
-      "description" => event.fetch("Description",  I18n.t("manifold.default.event.description")),
+      "title" => event.fetch("Title", nil),
+      "description" => event.fetch("Description", nil),
       "tags" => event.fetch("Tags", nil),
       "event_type" => event.fetch("Type", nil),
       "cancelled" => event.fetch("Canceled", 0),
-      "registration_status" => event.fetch("RegistrationStatus", I18n.t("manifold.default.event.registration_status")),
+      "registration_status" => event.fetch("RegistrationStatus", nil),
       "registration_link" => event.fetch("RegistrationLink", nil),
       "start_time" => start_time(event),
       "end_time" => end_time(event),
@@ -98,9 +98,9 @@ class SyncService::Events
       { "person" => contact_person }
     else
       {
-        "external_contact_name"  => contact_name || I18n.t("manifold.default.event.contact_name"),
-        "external_contact_email" => event.fetch("ContactEmail") { I18n.t("manifold.default.event.contact_email") },
-        "external_contact_phone" => event.fetch("ContactPhone") { I18n.t("manifold.default.event.contact_phone") }
+        "external_contact_name"  => contact_name || nil,
+        "external_contact_email" => event.fetch("ContactEmail") { nil },
+        "external_contact_phone" => event.fetch("ContactPhone") { nil }
       }
     end
   end
@@ -114,11 +114,11 @@ class SyncService::Events
     if building
       location_hash["building"] = building
     else
-      location_hash["external_building"] = location || I18n.t("manifold.default.event.building")
-      location_hash["external_address"] = event.fetch("Address") { I18n.t("manifold.default.event.external_address") }
-      location_hash["external_city"] = event.fetch("City") { I18n.t("manifold.default.event.external_city") }
-      location_hash["external_state"] = event.fetch("State") { I18n.t("manifold.default.event.external_state") }
-      location_hash["external_zip"] = event.fetch("Zip") { I18n.t("manifold.default.event.external_zip") }
+      location_hash["external_building"] = location || nil
+      location_hash["external_address"] = event.fetch("Address") { nil }
+      location_hash["external_city"] = event.fetch("City") { nil }
+      location_hash["external_state"] = event.fetch("State") { nil }
+      location_hash["external_zip"] = event.fetch("Zip") { nil }
     end
 
     room = event.fetch("Room", nil)
@@ -127,7 +127,7 @@ class SyncService::Events
     if space
       location_hash["space"] = space
     else
-      location_hash["external_space"] = room || I18n.t("manifold.default.event.space")
+      location_hash["external_space"] = room || nil
     end
     location_hash
   end


### PR DESCRIPTION
#MAN-246 

The events sync service writes default values from en.yml when a field has no value in the xml feed. These should be removed from the service and null values dealt with in the views.

****************
Removed setting translations for empty fields in the sync service and substituted nil.