### PR TITLE
#MAN-231 Add a photo concern for consistency

### DIFF
--- a/app/dashboards/building_dashboard.rb
+++ b/app/dashboards/building_dashboard.rb
@@ -9,7 +9,7 @@ class BuildingDashboard < BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    photo: PhotoField.with_options(admin_only: true),
+    image: PhotoField.with_options(admin_only: true),
     name: Field::String,
     description: DescriptionField,
     address1: Field::String,
@@ -41,7 +41,7 @@ class BuildingDashboard < BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :photo,
+    :image,
     :name,
     :description,
     :address1,
@@ -59,7 +59,7 @@ class BuildingDashboard < BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
-    :photo,
+    :image,
     :description,
     :campus,
     :address1,

--- a/app/dashboards/collection_dashboard.rb
+++ b/app/dashboards/collection_dashboard.rb
@@ -18,7 +18,7 @@ class CollectionDashboard < Administrate::BaseDashboard
     ),
     # contents: DescriptionField,
     space: Field::BelongsTo,
-    photo: PhotoField,
+    image: PhotoField,
     add_to_footer: Field::Boolean.with_options(admin_only: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -47,7 +47,7 @@ class CollectionDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
-    :photo,
+    :image,
     :description,
     :subject,
     # :contents,

--- a/app/dashboards/exhibition_dashboard.rb
+++ b/app/dashboards/exhibition_dashboard.rb
@@ -13,7 +13,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
     group: Field::BelongsTo,
     space: Field::BelongsTo.with_options(required: true),
     collection: Field::BelongsTo,
-    photo: PhotoField,
+    image: PhotoField,
     id: Field::Number,
     title: Field::String,
     description: Field::Text,
@@ -39,7 +39,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :title,
-    :photo,
+    :image,
     :description,
     :start_date,
     :end_date,
@@ -53,7 +53,7 @@ class ExhibitionDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :title,
-    :photo,
+    :image,
     :description,
     :start_date,
     :end_date,

--- a/app/dashboards/highlight_dashboard.rb
+++ b/app/dashboards/highlight_dashboard.rb
@@ -11,7 +11,7 @@ class HighlightDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    photo: PhotoField,
+    image: PhotoField,
     title: Field::String,
     blurb: Field::Text,
     link_label: Field::String,
@@ -39,7 +39,7 @@ class HighlightDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :photo,
+    :image,
     :title,
     :blurb,
     :link_label,
@@ -52,7 +52,7 @@ class HighlightDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :photo,
+    :image,
     :title,
     :blurb,
     :link_label,

--- a/app/dashboards/person_dashboard.rb
+++ b/app/dashboards/person_dashboard.rb
@@ -18,7 +18,7 @@ class PersonDashboard < BaseDashboard
     phone_number: PhoneField,
     email_address: Field::Email,
     chat_handle: Field::String,
-    photo: PhotoField.with_options(admin_only: true),
+    image: PhotoField.with_options(admin_only: true),
     job_title: Field::String,
     specialties: MultiSelectField.with_options(
       collection: Rails.configuration.specialties,
@@ -47,7 +47,7 @@ class PersonDashboard < BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :first_name,
     :last_name,
-    :photo,
+    :image,
     :phone_number,
     :email_address,
     :chat_handle,
@@ -64,7 +64,7 @@ class PersonDashboard < BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :photo,
+    :image,
     :first_name,
     :last_name,
     :phone_number,

--- a/app/dashboards/space_dashboard.rb
+++ b/app/dashboards/space_dashboard.rb
@@ -18,7 +18,7 @@ class SpaceDashboard < BaseDashboard
     description: DescriptionField,
     hours: Field::String,
     accessibility: Field::Text,
-    photo: PhotoField.with_options(admin_only: true),
+    image: PhotoField.with_options(admin_only: true),
     phone_number: PhoneField,
     email: Field::Email,
     policies: Field::HasMany,
@@ -42,7 +42,7 @@ class SpaceDashboard < BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :name,
-    :photo,
+    :image,
     :description,
     :building,
     :persons,
@@ -58,7 +58,7 @@ class SpaceDashboard < BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
-    :photo,
+    :image,
     :description,
     :building,
     :email,

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -7,7 +7,7 @@ class Building < ApplicationRecord
   include HasPolicies
   include SetDates
   include Categorizable
-  include Photographable
+  include Imageable
   require "uploads"
 
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true
@@ -16,8 +16,6 @@ class Building < ApplicationRecord
 
   has_many :library_hours
   has_many :spaces
-
-  has_one_attached :image, dependent: :destroy
 
   auto_strip_attributes :email
 

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -7,6 +7,7 @@ class Building < ApplicationRecord
   include HasPolicies
   include SetDates
   include Categorizable
+  include Photographable
   require "uploads"
 
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true
@@ -16,22 +17,10 @@ class Building < ApplicationRecord
   has_many :library_hours
   has_many :spaces
 
-  has_one_attached :photo, dependent: :destroy
+  has_one_attached :image, dependent: :destroy
 
   auto_strip_attributes :email
 
   before_validation :normalize_phone_number
   before_validation :sanitize_description
-
-
-  def index_image
-    variation =
-      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 250, height: 190, blob: photo.blob, gravity: "Center"))
-    ActiveStorage::Variant.new(photo.blob, variation)
-  end
-  def show_image
-    variation =
-      ActiveStorage::Variation.new(Uploads.resize_to_fill(width: 600, height: 450, blob: photo.blob, gravity: "Center"))
-    ActiveStorage::Variant.new(photo.blob, variation)
-  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,11 +4,12 @@ class Collection < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
+  include Photographable
 
   validates :name, :description, presence: true
 
   belongs_to :space
-  has_one_attached :photo, dependent: :destroy
+  has_one_attached :image, dependent: :destroy
 
   has_many :collection_aids
   has_many :finding_aids, through: :collection_aids

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,12 +4,11 @@ class Collection < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
-  include Photographable
+  include Imageable
 
   validates :name, :description, presence: true
 
   belongs_to :space
-  has_one_attached :image, dependent: :destroy
 
   has_many :collection_aids
   has_many :finding_aids, through: :collection_aids

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-module Photographable
+module Imageable
   extend ActiveSupport::Concern
+
+  included do
+    has_one_attached :image, dependent: :destroy
+  end
 
   def index_image
     image.variant(image_variation(220, 220)).processed

--- a/app/models/concerns/photographable.rb
+++ b/app/models/concerns/photographable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Photographable
+  extend ActiveSupport::Concern
+
+  def index_image
+    image.variant(image_variation(220, 220)).processed
+  end
+
+  def thumb_image
+    image.variant(image_variation(120, 120)).processed
+  end
+
+  def show_image
+    image.variant(image_variation(300, 300)).processed
+  end
+
+  def image_variation(width, height)
+    ActiveStorage::Variation.new(Uploads.resize_to_fill(width: width, height: height, blob: image.blob, gravity: "Center"))
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,13 +4,12 @@ class Event < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
-  include Photographable
+  include Imageable
 
   paginates_per 5
   belongs_to :building, optional: true
   belongs_to :space, optional: true
   belongs_to :person, optional: true
-  has_one_attached :image, dependent: :destroy
 
   before_save :sanitize_description
 
@@ -54,5 +53,4 @@ class Event < ApplicationRecord
       "(All day)"
     end
   end
-
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@ class Event < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
+  include Photographable
 
   paginates_per 5
   belongs_to :building, optional: true
@@ -38,17 +39,5 @@ class Event < ApplicationRecord
     else
       "All Day"
     end
-  end
-
-  def index_image
-    image.variant(centered_image_variation(220, 220)).processed
-  end
-
-  def show_image
-    image.variant(centered_image_variation(300, 300)).processed
-  end
-
-  def centered_image_variation(width, height)
-    ActiveStorage::Variation.new(Uploads.resize_to_fill(width: width, height: height, blob: image.blob, gravity: "Center"))
   end
 end

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -4,12 +4,11 @@ class Exhibition < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
-  include Photographable
+  include Imageable
 
   belongs_to :group, optional: true
   belongs_to :space, optional: true
   belongs_to :collection, optional: true
-  has_one_attached :image, dependent: :destroy
 
   before_save :sanitize_description
 end

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -4,11 +4,12 @@ class Exhibition < ApplicationRecord
   has_paper_trail
   include InputCleaner
   include Categorizable
+  include Photographable
 
   belongs_to :group, optional: true
   belongs_to :space, optional: true
   belongs_to :collection, optional: true
-  has_one_attached :photo, dependent: :destroy
+  has_one_attached :image, dependent: :destroy
 
   before_save :sanitize_description
 end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class Highlight < ApplicationRecord
-  include Photographable
+  include Imageable
   has_paper_trail
 
-  has_one_attached :image, dependent: :destroy
   serialize :tags
 end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Highlight < ApplicationRecord
+  include Photographable
   has_paper_trail
-  has_one_attached :photo, dependent: :destroy
+
+  has_one_attached :image, dependent: :destroy
   serialize :tags
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,6 +5,7 @@ class Person < ApplicationRecord
   include Validators
   include InputCleaner
   include Categorizable
+  include Photographable
 
   validates :first_name, :last_name, :job_title, presence: true
   validates :email_address, presence: true, email: true
@@ -13,7 +14,7 @@ class Person < ApplicationRecord
 
   serialize :specialties
 
-  has_one_attached :photo, dependent: :destroy
+  has_one_attached :image, dependent: :destroy
 
   auto_strip_attributes :email_address
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,7 +5,7 @@ class Person < ApplicationRecord
   include Validators
   include InputCleaner
   include Categorizable
-  include Photographable
+  include Imageable
 
   validates :first_name, :last_name, :job_title, presence: true
   validates :email_address, presence: true, email: true
@@ -13,8 +13,6 @@ class Person < ApplicationRecord
   validates :spaces, presence: true
 
   serialize :specialties
-
-  has_one_attached :image, dependent: :destroy
 
   auto_strip_attributes :email_address
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -7,7 +7,7 @@ class Space < ApplicationRecord
   include HasPolicies
   include SetDates
   include Categorizable
-  include Photographable
+  include Imageable
   has_ancestry
 
   validates :name, presence: true
@@ -18,8 +18,6 @@ class Space < ApplicationRecord
   before_validation :sanitize_description
 
   auto_strip_attributes :email
-
-  has_one_attached :image, dependent: :destroy
 
   before_validation :normalize_phone_number
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -7,6 +7,7 @@ class Space < ApplicationRecord
   include HasPolicies
   include SetDates
   include Categorizable
+  include Photographable
   has_ancestry
 
   validates :name, presence: true
@@ -18,7 +19,7 @@ class Space < ApplicationRecord
 
   auto_strip_attributes :email
 
-  has_one_attached :photo, dependent: :destroy
+  has_one_attached :image, dependent: :destroy
 
   before_validation :normalize_phone_number
 

--- a/app/schemas/building_schema.json
+++ b/app/schemas/building_schema.json
@@ -158,10 +158,10 @@
 							],
 							"pattern": "^(.*)$"
 						},
-						"thumbnail_photo": {
-							"$id": "#/properties/data/properties/attributes/properties/thumbnail_photo",
+						"thumbnail_image": {
+							"$id": "#/properties/data/properties/attributes/properties/thumbnail_image",
 							"type": "string",
-							"title": "The Thumbnail_photo Schema",
+							"title": "The Thumbnail_image Schema",
 							"default": "",
 							"examples": [
 								"http://test.host/rails/active_storage/representations/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBDUT09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c3d4d92bfe42cae216c67817d111ef844220162e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9MY21WemFYcGxTU0lNTVRBd2VERXdNQVk2QmtWVSIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--1780aa09167cc24cd4beae09f819f90d80b64c3a/ambler.jpg"

--- a/app/schemas/person_schema.json
+++ b/app/schemas/person_schema.json
@@ -140,10 +140,10 @@
               ],
               "pattern": "^(.*)$"
             },
-            "thumbnail_photo": {
-              "$id": "#/properties/data/properties/attributes/properties/thumbnail_photo",
+            "thumbnail_image": {
+              "$id": "#/properties/data/properties/attributes/properties/thumbnail_image",
               "type": "string",
-              "title": "The Thumbnail_photo Schema",
+              "title": "The Thumbnail_image Schema",
               "default": "",
               "examples": [
                 "http://test.host/rails/active_storage/representations/zaphod2_1024x768.jpg"

--- a/app/serializers/building_serializer.rb
+++ b/app/serializers/building_serializer.rb
@@ -13,11 +13,11 @@ class BuildingSerializer
 
   attributes :name, :description, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, :phone_number
 
-  attribute :photo, if: Proc.new { |building| building.photo.attached? } do |building|
-    helpers.rails_blob_url(building.photo)
+  attribute :image, if: Proc.new { |building| building.image.attached? } do |building|
+    helpers.rails_blob_url(building.image)
   end
 
-  attribute :thumbnail_photo, if: Proc.new { |building| building.photo.attached? } do |building|
+  attribute :thumbnail_image, if: Proc.new { |building| building.image.attached? } do |building|
     helpers.rails_representation_url(building.index_image)
   end
 

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -10,12 +10,12 @@ class PersonSerializer
   link :self, Proc.new { |person| helpers.url_for(person) }
 
   attributes :name, :first_name, :last_name, :job_title, :email_address, :phone_number, :specialties
-  attribute :photo, if: Proc.new { |person| person.photo.attached? } do |person|
-    helpers.rails_blob_url(person.photo)
+  attribute :image, if: Proc.new { |person| person.image.attached? } do |person|
+    helpers.rails_blob_url(person.image)
   end
 
-  attribute :thumbnail_photo, if: Proc.new { |person| person.photo.attached? } do |person|
-    helpers.rails_representation_url(person.photo.variant(resize: "100x100").processed)
+  attribute :thumbnail_image, if: Proc.new { |person| person.image.attached? } do |person|
+    helpers.rails_representation_url(person.image.variant(resize: "100x100").processed)
   end
 
   has_many :groups

--- a/app/views/application/_highlights-row.html.erb
+++ b/app/views/application/_highlights-row.html.erb
@@ -2,8 +2,8 @@
   <div class="col-12 col-xl-3">
     <div class="card cta<%= (index+1).ordinalize %> ">
 
-      <% if highlight.photo.attached?  %>
-        <%= image_tag highlight.photo.variant(resize: '360x360', gravity: 'center'), class: "d-none d-xl-block card-img-top", alt: "" %>
+      <% if highlight.image.attached?  %>
+        <%= image_tag highlight.image_variant(360,360), class: "d-none d-xl-block card-img-top", alt: "" %>
       <% else %>
         <%= image_tag "T.gif", style: 'width: 300px;' %>
       <% end %>

--- a/app/views/buildings/_spaces.html.erb
+++ b/app/views/buildings/_spaces.html.erb
@@ -14,10 +14,10 @@
     <% @building.spaces.each do |space| %>
       <div class="col-12 col-sm-6 col-md-4 col-lg-3 ctaTwo text-center">
         <div class="related_space">
-          <% if space.photo.attached? %>
-            <%= link_to image_tag(space.photo.variant(gravity: 'center', crop: "200x200+50%+50%", extent: "100%x100%"), class: "card-img-top", alt: "Card image cap"), space_path(space) %>
+          <% if space.image.attached? %>
+            <%= link_to image_tag(space.index_image, class: "card-img-top", alt: ""), space_path(space) %>
           <% else %>
-            <%= link_to image_tag('T-borderless.gif', class: "card-img-top", alt: "Card image cap"), space_path(space) %>
+            <%= link_to image_tag('T-borderless.gif', class: "card-img-top", alt: ""), space_path(space) %>
           <% end %>
         </div>
         <div class="card-body" style="padding: 0;">

--- a/app/views/buildings/index.html.erb
+++ b/app/views/buildings/index.html.erb
@@ -20,8 +20,8 @@
     <% @buildings.each do |building| %>
       <div class="col-12 col-sm-6 col-lg-3 text-center" >
         <div class="card">
-          <% if building.photo.attached? %>
-            <%= link_to image_tag(building.index_image, class: "lib-image", alt: ""), building_path(building) %>
+          <% if building.image.attached? %>
+            <%= link_to image_tag(building.image_variation(250,190), class: "lib-image", alt: ""), building_path(building) %>
           <% else %>
             <%= link_to image_tag('T-borderless.gif', class: "default-image", alt: ""), building_path(building) %>
           <% end %>

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -10,8 +10,8 @@
 <div class="row building-info">
   <div class="d-none d-xl-block col-xl-6 text-center text-xl-right">
     <div class="building-image">
-      <% if @building.photo.attached? %>
-        <%= image_tag @building.photo.variant(gravity: 'center', extent: "100%x100%") %>
+      <% if @building.image.attached? %>
+        <%= image_tag @building.image_variation(600,450) %>
       <% else %>
         <%= image_tag 'T-borderless.gif' %>
       <% end %>

--- a/app/views/collections/finding_aids.html.erb
+++ b/app/views/collections/finding_aids.html.erb
@@ -11,8 +11,8 @@
     <h2 class="unstyled"><%= @collection.name %></h2>
     <div class="row">
     	<div class="col-4 text-center">
-          <% if @collection.photo.attached? %>
-            <%= image_tag @collection.photo.variant(gravity: 'center', extent: "100%x100%") %>
+          <% if @collection.image.attached? %>
+            <%= image_tag @collection.show_image %>
           <% else %>
             <%= image_tag 'T-borderless.gif' %>
           <% end %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -11,10 +11,10 @@
     <h2 class="unstyled" style=""><%= @collection.name %></h2>
     <div class="row info">
     	<div class="col-4" style="padding-left: 0;">
-          <% if @collection.photo.attached? %>
-            <%= image_tag @collection.photo.variant(gravity: 'center', extent: "100%x100%") %>
+          <% if @collection.image.attached? %>
+            <%= image_tag @collection.show_image, alt: "" %>
           <% else %>
-            <%= image_tag 'T-borderless.gif' %>
+            <%= image_tag 'T-borderless.gif', alt: "" %>
           <% end %>
     	</div>
     	<div class="col-8" style="padding-left:21px;">

--- a/app/views/exhibitions/show.html.erb
+++ b/app/views/exhibitions/show.html.erb
@@ -10,8 +10,8 @@
 <div class="row building-info">
   <div class="col-lg-12 col-xl-6 text-center text-xl-right">
     <div class="building-image">
-      <% if @exhibition.photo.attached? %>
-        <%= image_tag @exhibition.photo.variant(gravity: 'center', extent: "100%x100%") %>
+      <% if @exhibition.image.attached? %>
+        <%= image_tag @exhibition.show_image %>
       <% else %>
         <%= image_tag 'T-borderless.gif' %>
       <% end %>

--- a/app/views/groups/_show_members.html.erb
+++ b/app/views/groups/_show_members.html.erb
@@ -16,14 +16,14 @@
         <div class="spacer l-end">
           <div class="title">
                 <%= link_to (person.first.first_name+' '+person.first.last_name), 
-                      controller: 'persons', action: 'show', id: person.first.id %></div>
+                      person_path(person.first) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.first.photo.attached? %>
-                  <%= link_to image_tag(person.first.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.first.id %>
+                <% if person.first.image.attached? %>
+                  <%= link_to image_tag(person.first.thumb_image), 
+                      person_path(person.first) %>
                 <% else %>
-                  <%= link_to image_tag 'T-borderless.gif',controller: 'persons', action: 'show', id: person.first.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.first) %>
                 <% end %>
               </div>
               <div class="details">
@@ -53,14 +53,13 @@
         <div class="spacer">
           <div class="title">
                 <%= link_to (person.second.first_name+' '+person.second.last_name), 
-                      controller: 'persons', action: 'show', id: person.second.id %></div>
+                      person_path(person.second) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.second.photo.attached? %>
-                  <%= link_to image_tag(person.second.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.second.id %>
+                <% if person.second.image.attached? %>
+                  <%= link_to image_tag(person.second.thumb_image), person_path(person.second) %>
                 <% else %>
-                  <%= link_to image_tag 'T-borderless.gif',controller: 'persons', action: 'show', id: person.second.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.second) %>
                 <% end %>
               </div>
               <div class="details">
@@ -90,14 +89,14 @@
         <div class="spacer r-end">
           <div class="title">
                 <%= link_to (person.third.first_name+' '+person.third.last_name), 
-                      controller: 'persons', action: 'show', id: person.third.id %></div>
+                      person_path(person.third) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.third.photo.attached? %>
-                  <%= link_to image_tag(person.third.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.third.id %>
+                <% if person.third.image.attached? %>
+                  <%= link_to image_tag(person.third.thumb_image), 
+                      person_path(person.third) %>
                 <% else %>
-                  <%= link_to image_tag 'T-borderless.gif',controller: 'persons', action: 'show', id: person.third.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.third) %>
                 <% end %>
               </div>
               <div class="details">
@@ -130,14 +129,13 @@
         <div class="spacer l-end">
           <div class="title">
                 <%= link_to (person.first.first_name+' '+person.first.last_name), 
-                      controller: 'persons', action: 'show', id: person.first.id %></div>
+                      person_path(person.first) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.first.photo.attached? %>
-                  <%= link_to image_tag(person.first.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.first.id %>
+                <% if person.first.image.attached? %>
+                  <%= link_to image_tag(person.first.thumb_image), person_path(person.first) %>
                 <% else %>
-                  <%= link_to image_tag 'T-borderless.gif',controller: 'persons', action: 'show', id: person.first.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.first) %>
                 <% end %>
               </div>
               <div class="details">
@@ -165,15 +163,13 @@
         <% end %>
         <div class="spacer r-end">
           <div class="title">
-                <%= link_to (person.second.first_name+' '+person.second.last_name), 
-                      controller: 'persons', action: 'show', id: person.second.id %></div>
+                <%= link_to (person.second.first_name+' '+person.second.last_name), person_path(person.second) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.second.photo.attached? %>
-                  <%= link_to image_tag(person.second.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.second.id %>
+                <% if person.second.image.attached? %>
+                  <%= link_to image_tag(person.second.thumb_image), person_path(person.second) %>
                 <% else %>
-                  <%= link_to image_tag 'T-borderless.gif',controller: 'persons', action: 'show', id: person.second.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.second) %>
                 <% end %>
               </div>
               <div class="details">
@@ -205,14 +201,13 @@
         <div class="spacer both-ends">
           <div class="title">
                 <%= link_to (person.first.first_name+' '+person.first.last_name), 
-                      controller: 'persons', action: 'show', id: person.first.id %></div>
+                      person_path(person.first) %></div>
             <div class="info">
               <div class="photo">
-                <% if person.first.photo.attached? %>
-                  <%= link_to image_tag(person.first.photo.variant(resize: "120x120>", extent: "120x120")), 
-                      controller: 'persons', action: 'show', id: person.first.id %>
+                <% if person.first.image.attached? %>
+                  <%= link_to image_tag(person.first.thumb_image), person_path(person.first) %>
                 <% else %>
-                  <%= link_to image_tag('T-borderless.gif'), controller: 'persons', action: 'show', id: person.first.id %>
+                  <%= link_to (image_tag 'T-borderless.gif'), person_path(person.first) %>
                 <% end %>
               </div>
               <div class="details">

--- a/app/views/persons/show.html.erb
+++ b/app/views/persons/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col breadcrumbs" style="margin-bottom: 35px;">
     <%= link_to "Home", root_path.to_s %> 
-    <%= link_to "People", controller: 'persons', action: :index %> 
+    <%= link_to "People", people_path %> 
     <%= @person.first_name %> <%= @person.last_name %>
   </div>
 </div>
@@ -13,8 +13,8 @@
   <div class="col-sm-12 offset-sm-1 col-lg-6">
     <div class="row" style="display: table;">
       <div class="col-3" style="width: 35%;display: table-cell;vertical-align:middle;">
-        <% if @person.photo.attached?  %>
-          <%= image_tag @person.photo.variant(resize: '300x300', gravity: 'center', extent: '300x300'), style: '' %>
+        <% if @person.image.attached?  %>
+          <%= image_tag @person.show_image, alt: "" %>
         <% else %> 
           <%= image_tag "T.gif", style: 'margin-top: 28px;width: 300px;' %>
         <% end %>

--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -20,10 +20,10 @@
     <% @spaces.each do |space| %>
       <div class="col-12 col-sm-6 col-md-4 col-lg-3 ctaTwo text-center">
         <div class="related_space">
-          <% if space.photo.attached? %>
-            <%= link_to image_tag(space.photo.variant(gravity: 'center', crop: "200x200+50%+50%", extent: "100%x100%"), class: "card-img-top", alt: "Card image cap"), space_path(space) %>
+          <% if space.image.attached? %>
+            <%= link_to image_tag(space.index_image, class: "card-img-top", alt: ""), space_path(space) %>
           <% else %>
-            <%= link_to image_tag('T-borderless.gif', class: "card-img-top", alt: "Card image cap"), space_path(space) %>
+            <%= link_to image_tag('T-borderless.gif', class: "card-img-top", alt: ""), space_path(space) %>
           <% end %>
         </div>
         <div class="card-body" style="padding: 0;">

--- a/app/views/spaces/show.html.erb
+++ b/app/views/spaces/show.html.erb
@@ -9,10 +9,10 @@
 <div class="row space-info">
   <div class="d-none d-xl-block col-lg-12 col-xl-6 text-center text-xl-right">
     <div class="space-image">
-      <% if @space.photo.attached? %>
-        <%= image_tag @space.photo.variant(gravity: 'center', extent: "100%x100%") %>
+      <% if @space.image.attached? %>
+        <%= image_tag @space.show_image, alt: "" %>
       <% else %>
-        <%= image_tag 'T-borderless.gif' %>
+        <%= image_tag 'T-borderless.gif', alt: "" %>
       <% end %>
     </div>
   </div>

--- a/spec/controllers/buildings_controller_spec.rb
+++ b/spec/controllers/buildings_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BuildingsController, type: :controller do
 
 
   describe "GET #show as JSON" do
-    let(:building) { FactoryBot.create(:building, :with_photo) }
+    let(:building) { FactoryBot.create(:building, :with_image) }
 
     it "returns valid json" do
       get :show, format: :json, params: { id: building.id }

--- a/spec/controllers/persons_controller_spec.rb
+++ b/spec/controllers/persons_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PersonsController, type: :controller do
   end
 
   describe "GET #show as JSON" do
-    let(:person) { FactoryBot.create(:person, :with_photo) }
+    let(:person) { FactoryBot.create(:person, :with_image) }
 
     it "returns valid json" do
       get :show, format: :json, params: { id: person.to_param }

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -15,11 +15,11 @@ FactoryBot.define do
     phone_number { "2155551212" }
     campus { "Main Campus" }
     email { "csa@example.edu" }
-    trait :with_photo do
+    trait :with_image do
       after :create do |building|
         file_path = Rails.root.join("spec", "fixtures", "charles.jpg")
         file = fixture_file_upload(file_path, "image/png")
-        building.photo.attach(file)
+        building.image.attach(file)
       end
     end
 

--- a/spec/factories/persons.rb
+++ b/spec/factories/persons.rb
@@ -13,11 +13,11 @@ FactoryBot.define do
     springshare_id { "0123-4567-8901" }
     spaces { [FactoryBot.create(:space)] }
     specialties { ["", "first subject"] }
-    trait :with_photo do
+    trait :with_image do
       after :create do |person|
         file_path = Rails.root.join("spec", "support", "assets", "hal.png")
         file = fixture_file_upload(file_path, "image/png")
-        person.photo.attach(file)
+        person.image.attach(file)
       end
     end
   end

--- a/spec/factories/spaces.rb
+++ b/spec/factories/spaces.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     accessibility { "Yes" }
     phone_number { "2155551213" }
     email { "mmuffley@example.com" }
-    image { "https://diefenbunker.files.wordpress.com/2012/05/dr-strangelove-warroom.jpg" }
+    image { Rails.root.join("spec", "fixtures", "charles.jpg") }
     association :building
 
     factory :space_with_parent do

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -79,4 +79,5 @@ RSpec.describe Building, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -46,4 +46,5 @@ RSpec.describe Collection, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -128,4 +128,5 @@ RSpec.describe Event, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 end

--- a/spec/models/exhibition_spec.rb
+++ b/spec/models/exhibition_spec.rb
@@ -24,5 +24,6 @@ RSpec.describe Exhibition, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -94,4 +94,5 @@ RSpec.describe Person, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -99,5 +99,6 @@ RSpec.describe Space, type: :model do
   end
 
   it_behaves_like "categorizable"
+  it_behaves_like "imageable"
 
 end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Space, type: :model do
       hours: ["The Text 1", "The Text 2"],
       accessibility: ["https://example.com/doc1", "https://example.com/doc2"],
       phone_number: ["2155551212", "2155551234"],
-      image: ["https://example.com/image1.jpg", "https://example.com/image2.png"],
       email: ["first@example.com", "second@email.com"],
     }
 

--- a/spec/serializers/building_serializer_spec.rb
+++ b/spec/serializers/building_serializer_spec.rb
@@ -27,24 +27,24 @@ RSpec.describe BuildingSerializer do
       expect(data[:links][:self]).to eql Rails.application.routes.url_helpers.url_for(building)
     end
 
-    describe "building with photo" do
-      let (:building) { FactoryBot.create(:building, :with_photo) }
+    describe "building with image" do
+      let (:building) { FactoryBot.create(:building, :with_image) }
 
-      it "has the photo and thumbnail attributes" do
-        expect(data[:attributes].keys).to include(:photo, :thumbnail_photo)
+      it "has the image and thumbnail attributes" do
+        expect(data[:attributes].keys).to include(:image, :thumbnail_image)
       end
 
-      describe "photo attribute" do
+      describe "image attribute" do
         it "returns an valid url" do
-          photo_url = data[:attributes][:photo]
-          expect(photo_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
+          image_url = data[:attributes][:image]
+          expect(image_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
         end
       end
 
-      describe "thumbnail_photo attribute" do
+      describe "thumbnail_image attribute" do
         it "returns an valid url" do
-          photo_url = data[:attributes][:thumbnail_photo]
-          expect(photo_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
+          image_url = data[:attributes][:thumbnail_image]
+          expect(image_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
         end
       end
     end

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -27,24 +27,24 @@ RSpec.describe PersonSerializer do
       expect(data[:links][:self]).to eql Rails.application.routes.url_helpers.url_for(person)
     end
 
-    describe "person with photo" do
-      let (:person) { FactoryBot.create(:person, :with_photo) }
+    describe "person with image" do
+      let (:person) { FactoryBot.create(:person, :with_image) }
 
-      it "has the photo and thumbnail attributes" do
-        expect(data[:attributes].keys).to include(:photo, :thumbnail_photo)
+      it "has the image and thumbnail attributes" do
+        expect(data[:attributes].keys).to include(:image, :thumbnail_image)
       end
 
-      describe "photo attribute" do
+      describe "image attribute" do
         it "returns an valid url" do
-          photo_url = data[:attributes][:photo]
-          expect(photo_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
+          image_url = data[:attributes][:image]
+          expect(image_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
         end
       end
 
-      describe "thumbnail_photo attribute" do
+      describe "thumbnail_image attribute" do
         it "returns an valid url" do
-          photo_url = data[:attributes][:thumbnail_photo]
-          expect(photo_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
+          image_url = data[:attributes][:thumbnail_image]
+          expect(image_url =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]).to be_truthy
         end
       end
     end

--- a/spec/support/imageable_spec.rb
+++ b/spec/support/imageable_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.shared_examples "imageable" do
+  let(:model) { described_class } # the class that includes the concern
+  let(:factory_model) { FactoryBot.create(model.to_s.underscore.to_sym) }
+  let(:image) {
+    file_path = Rails.root.join("spec", "fixtures", "charles.jpg")
+    file = fixture_file_upload(file_path, "image/png")
+    factory_model.image.attach(file)
+  }
+
+  it "has an image added to it" do
+    expect { image }.not_to raise_error
+  end
+
+  context "when it has no image" do
+    it "the image attachment returns nil when not assigned" do
+      expect(factory_model.image.attachment).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
#MAN-231 Add a photo concern for consistency

We have about 6 models that have an attached photo, as per https://github.com/tulibraries/manifold/search?q=has_one_attached+%3Aphoto%2C&unscoped_q=has_one_attached+%3Aphoto%2C

We'd like to provide consistent access to a full size and thumbnail images for each of those models, so it seems like adding a concern that adds model methods for a full size and thumbnail image would be useful.

******************************************

Add concern for photos; Update views, controllers, serializers, and tests to accommodate name change from photo to image.