### PR TITLE
Use event address when matching buildings

### DIFF
--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -116,7 +116,12 @@ class SyncService::Events
     location_hash = {}
 
     location = event.fetch("Location", nil)
-    building = FuzzyFind::Building.find(location.to_s)
+    address = event.fetch("Address", nil)
+
+    building = FuzzyFind::Building.find(
+      location.to_s,
+        addl_attribute: { address1: address.to_s }
+        )
 
     if building
       location_hash["building"] = building

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -35,4 +35,5 @@ FactoryBot.define do
       end
     end
   end
+
 end

--- a/spec/fixtures/files/fuzzy_events_internal.xml
+++ b/spec/fixtures/files/fuzzy_events_internal.xml
@@ -18,9 +18,9 @@
     <Tags>library workshops</Tags>
     <PrivateTags></PrivateTags>
     <Campus>Main Campus</Campus>
-    <Location>Addams Library</Location>
+    <Location>Paley Library</Location>
     <Room>Room 1</Room>
-    <Address>1115 W. Berks Street</Address>
+    <Address>1250 Polett Walk</Address>
     <City>Philadelphia</City>
     <State>PA</State>
     <Zip>19122</Zip>

--- a/spec/services/fuzzy_find/finder_service_spec.rb
+++ b/spec/services/fuzzy_find/finder_service_spec.rb
@@ -141,5 +141,24 @@ RSpec.describe FuzzyFind::FinderService do
         end
       end
     end
+
+    context "search for a building" do
+      before do
+        FactoryBot.create(:building, name: "McGaw Library")
+        @law = FactoryBot.create(:building, name: "Law Library")
+      end
+
+
+      it "does not return Law Library when Paley is search term" do
+        expect(described_class.call(
+                 needle: "Paley Library",
+                 haystack_model: Building,
+                 attribute: :name,
+                 addl_attribute: { address1: "1210 W. Berks Street" }
+                 )
+        ).not_to eql @law
+      end
+
+    end
   end
 end

--- a/spec/services/sync_events_spec.rb
+++ b/spec/services/sync_events_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe SyncService::Events, type: :service do
       @building = FactoryBot.create(:building)
       @space = FactoryBot.create(:space, building: @building)
       @person = FactoryBot.create(:person, spaces: [@space])
+      # create law library to ensure that the Paley Library event does not match
+      @law = FactoryBot.create(:building, name: "Law Library")
     end
 
     describe "contact" do
@@ -136,7 +138,10 @@ RSpec.describe SyncService::Events, type: :service do
 
     describe "location/building" do
       it "has a building reference" do
-        allow(::FuzzyFind::Building).to receive(:find).with(kind_of(String)).and_return(@building)
+        allow(::FuzzyFind::Building).to receive(:find)
+          .with(kind_of(String), kind_of(Hash))
+          .and_return(@building)
+
         internal_events.sync
         event = Event.find_by(building_id: @building.id)
         expect(event.building_id).to eq @building.id


### PR DESCRIPTION
Add the event address into the matching algorithm to lower the chance of
false positives in buidling matches.