### PR TITLE
Use reify instead of custom calls.

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-PaperTrail.serializer = PaperTrail::Serializers::JSON

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Admin::EventsController, type: :controller do
 
     before do
       sign_in(@account)
-
       @event = FactoryBot.create(:event, title: original_title, building: building, space: space, person: person)
       @event.update!(title: updated_title)
     end
@@ -39,7 +38,7 @@ RSpec.describe Admin::EventsController, type: :controller do
     end
 
     it "renders edit form with original values when selected" do
-      get :edit, params: { id: @event.to_param, version: @event.versions.first.to_param }
+      get :edit, params: { id: @event.to_param, version: @event.versions.last.to_param }
       expect(response.body).to match(original_title)
     end
   end


### PR DESCRIPTION
Also switch to a before_action filter instead of overriding edit.

Remove initializers to serialize as JSON.