### PR TITLE
Fixes Blog Sync not working from the Admin dashboard

### DIFF
--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -3,10 +3,8 @@
 module Admin
   class BlogsController < Admin::ApplicationController
     def sync_all
-      Blog.all.each do |b|
-        SyncService::Blogs.call(blog: b)
-      end
-      flash[:notice] = t("fortytude.admin.notification.all_blogs_synced")
+      SyncService::Blogs.call
+      flash[:notice] = t("manifold.admin.notification.all_blogs_synced")
       redirect_to admin_blogs_path
     end
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -4,7 +4,7 @@ class Blog < ApplicationRecord
   has_paper_trail
   include Validators
 
-  has_many :blog_posts
+  has_many :blog_posts, dependent: :destroy
 
   validates :title, presence: true
   validates :base_url, presence: true, url: true

--- a/app/services/sync_service/blogs.rb
+++ b/app/services/sync_service/blogs.rb
@@ -3,15 +3,14 @@
 require "open-uri"
 
 class SyncService::Blogs
-  def self.call(blog_id: nil)
-    unless blog_id
-      blog_ids = Blog.all.map { |b| b.id }
+  def self.call(blog: nil )
+    if blog.nil?
+      blogs = Blog.all
     else
-      blog_ids = [ blog_id.to_i ]
+      blogs = (blog.is_a? Blog) ? [ blog ] : [Blog.find(blog)]
     end
-    blog_ids.each do |blog_id|
-      blog = Blog.find(blog_id)
-      new(blog: blog).sync_blog_posts
+    blogs.each do |this_blog|
+      new(blog: this_blog).sync_blog_posts
     end
   end
 
@@ -19,7 +18,7 @@ class SyncService::Blogs
     # can specify just a file path or feed_path
     @feed_uri =  params[:blog].feed_path
     # if URI, prepend the base url
-    @feed_uri.prepend(params[:blog].base_url) if params[:blog].base_url
+    @feed_uri = "#{params[:blog].base_url}#{@feed_uri}" if params[:blog].base_url
     @blog_id = params[:blog].id
   end
 

--- a/app/services/sync_service/blogs.rb
+++ b/app/services/sync_service/blogs.rb
@@ -3,7 +3,7 @@
 require "open-uri"
 
 class SyncService::Blogs
-  def self.call(blog: nil )
+  def self.call(blog: nil)
     if blog.nil?
       blogs = Blog.all
     else

--- a/lib/tasks/blogs_sync.rake
+++ b/lib/tasks/blogs_sync.rake
@@ -4,6 +4,6 @@ namespace :sync do
   desc "sync blogs by ID (`rake sync:blogs[ID Number]`) or sync all (`rake sync:blogs`)"
   task :blogs, [:id] => :environment do |t, args|
     args.with_defaults(id: nil)
-    SyncService::Blogs.call(blog_id: args[:id])
+    SyncService::Blogs.call(blog: args[:id])
   end
 end

--- a/spec/controllers/admin/blogs_controller_spec.rb
+++ b/spec/controllers/admin/blogs_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "ostruct"
 
 RSpec.describe Admin::BlogsController, type: :controller do
   # Verify edit page for non-versioned model
@@ -21,8 +22,15 @@ RSpec.describe Admin::BlogsController, type: :controller do
 
   describe "GET #sync" do
     let (:blog) { FactoryBot.create(:blog)}
-    render_views true
+    before do
+      # Stub out the syn service so we don't actually make
+      # http requests for rss. We jut want to test that
+      # we are calling the service integration correctly 
+      allow(SyncService::Blogs).to receive(:new)
+        .and_return(OpenStruct.new(sync_blog_posts: nil))
+    end
     it "renders edit form" do
+
       post :sync, params: { blog_id: blog.id }
       expect(response).to redirect_to admin_blogs_path
     end

--- a/spec/controllers/admin/blogs_controller_spec.rb
+++ b/spec/controllers/admin/blogs_controller_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Admin::BlogsController, type: :controller do
   end
 
   describe "GET #sync" do
-    let (:blog) { FactoryBot.create(:blog)}
+    let (:blog) { FactoryBot.create(:blog) }
     before do
       # Stub out the syn service so we don't actually make
       # http requests for rss. We jut want to test that
-      # we are calling the service integration correctly 
+      # we are calling the service integration correctly
       allow(SyncService::Blogs).to receive(:new)
         .and_return(OpenStruct.new(sync_blog_posts: nil))
     end

--- a/spec/controllers/admin/blogs_controller_spec.rb
+++ b/spec/controllers/admin/blogs_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::BlogsController, type: :controller do
+  # Verify edit page for non-versioned model
+
+  before(:each) do
+    account = FactoryBot.create(:account, admin: true)
+    sign_in(account)
+  end
+
+  describe "GET #sync_all" do
+    render_views true
+    it "renders edit form" do
+
+      post :sync_all
+      expect(response).to redirect_to admin_blogs_path
+    end
+  end
+
+  describe "GET #sync" do
+    let (:blog) { FactoryBot.create(:blog)}
+    render_views true
+    it "renders edit form" do
+      post :sync, params: { blog_id: blog.id }
+      expect(response).to redirect_to admin_blogs_path
+    end
+  end
+end


### PR DESCRIPTION
Additionally, refactors the service a bit to reduce the number of DB calls and leverage the services built in ability to sync all blogs.

Adds some tests for the sync and sync_all methods on the Admin::BlogsController.

Additionally, updates Blogs model to destroy dependent blogposts when the Blog is deleted.