### PR TITLE
#MAN-310 Revise Responsive menus

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,6 +29,7 @@ function toggle(x) {
   // }
   if (x == "secondary") {
   	document.getElementById("sub-toggler-icon").classList.toggle("change");
+    document.getElementById("mobile-navbar-brand").innerHTML = "See Less"
   }
   else if (x == "search") {
   	document.getElementById("search-toggler-icon").classList.toggle("change");

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -3,6 +3,7 @@
 class ServicesController < ApplicationController
   load_and_authorize_resource
   before_action :set_service, only: [:show]
+  before_action :navigation_items, only: [:show]
 
   def index
     @services = Service.all
@@ -20,6 +21,17 @@ class ServicesController < ApplicationController
     respond_to do |format|
       format.html
       format.json { render json: ServiceSerializer.new(@service) }
+    end
+  end
+
+  def navigation_items
+    @nav_items = []
+    @categories.each do |cat|
+      cat.items.each do |item|
+        unless item.id == @service.id
+          @nav_items << item
+        end
+      end
     end
   end
 

--- a/app/views/services/_all_services.html.erb
+++ b/app/views/services/_all_services.html.erb
@@ -1,8 +1,13 @@
 <% @categories.each do |cat| %>
   <div class="leftside-index">
-    <div class="index-category">
-      <h2><%= cat.name %></h2>
-    </div>
+    <% unless @categories.size > 1 %>
+      <div class="index-category">
+    <% else %>
+      <div class="d-none d-lg-block index-category">
+    <% end %>
+        <h2><%= cat.name %> menu</h2>
+      </div>
+
     <div class="index-items">
       <div>
         <ul class="list-unstyled">
@@ -12,7 +17,7 @@
             <% else %>
             <li>
             <% end %>
-              <%= link_to c.title, service_path(c) %>
+              <%= link_to c.label, url_for(c) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/services/_mobile_menu.html.erb
+++ b/app/views/services/_mobile_menu.html.erb
@@ -8,15 +8,12 @@
           <div class="bar2"></div>
           <div class="bar3"></div>
         </span>
-        <span class="navbar-brand">
-          <% @categories.each do |i| %>
-            <%= i.name %> 
-          <% end %> Menu</span>
+        <span id="mobile-navbar-brand" class="navbar-brand">See More</span>
       </button>
     </div>
     <div class="collapse navbar-collapse" id="services-mobile-menu">
       <div class="navbar-nav"> 
-         <%= render "all_services" %>
+         <%= render "mobile_services" %>
       </div>
     </div>
   </nav>

--- a/app/views/services/_mobile_services.html.erb
+++ b/app/views/services/_mobile_services.html.erb
@@ -1,0 +1,11 @@
+<div class="leftside-index">
+  <div class="index-items">
+    <ul class="list-unstyled">
+      <% @nav_items.flatten.uniq.each do |c| %>
+        <li>
+          <%= link_to c.label, url_for(c) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,20 +15,20 @@ Rails.application.routes.draw do
     resources :alerts
     resources :blogs
     resources :buildings
+    resources :categories
     resources :collections
     resources :events
     resources :exhibitions
-    resources :groups
+    resources :external_links
     resources :finding_aids
+    resources :groups
     resources :highlights
-    resources :pages
     resources :library_hours
+    resources :pages
     resources :people
     resources :policies
     resources :services
     resources :spaces
-    resources :categories
-    resources :external_links
 
     resource :events do
       member do


### PR DESCRIPTION
Updated secondary menu per ticket.

This should act as the navigation for all models displaying left-side categories but will need to included in each model's templates.

This can only be seen on the Services model, as of now.

(Also re-ordered administrate menu items in routes.rb to be alphabetical)