### PR TITLE
#Man-346 hours display for buildings and spaces

### DIFF
--- a/app/assets/stylesheets/partials/_hours.scss
+++ b/app/assets/stylesheets/partials/_hours.scss
@@ -22,9 +22,6 @@
 	}
 	.closed {
 		color: $red;
-		/*display:inline-block;
-		width: 100%;
-		text-align:center;*/
 	}
 	.date-nav {
 		background-color: $light-grey;
@@ -42,4 +39,11 @@
 	}
 	.date-range {
 		font-size: large;
+	}
+	.hours-header {
+		margin-top: 35px;
+	}
+	.hours-month-name {
+		font-weight: 600;
+		font-size: 150%;
 	}

--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -29,38 +29,7 @@ class LibraryHoursController < ApplicationController
   end
 
   def buildings
-    @buildings = [
-      {
-        slug: "ambler",
-        spaces: ["ambler"]
-      },
-      {
-        slug: "blockson",
-        spaces: ["blockson"]
-      },
-      {
-        slug: "charles",
-        spaces: [
-                  "charles",
-                  "service_zone",
-                  "cafe",
-                  "scrc",
-                  "scholars_studio",
-                  "success_center",
-                  "ask_a_librarian",
-                  "asrs",
-                  "guest_computers"
-                ]
-      },
-      {
-        slug: "ginsburg",
-        spaces: ["ginsburg", "innovation"]
-      },
-      {
-        slug: "podiatry",
-        spaces: ["podiatry"]
-      }
-    ]
+    @buildings = Rails.configuration.building_spaces
   end
 
   def build_hours_data_structure(input)

--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -1,44 +1,12 @@
 # frozen_string_literal: true
 
 class LibraryHoursController < ApplicationController
-  before_action :get_locations, :set_dates, only: [:index]
+  before_action :buildings, :set_dates, only: [:index, :show]
 
   def index
-    @buildings = [
-      {
-        slug: "charles",
-        spaces: [
-                  "charles",
-                  "service_zone",
-                  "cafe",
-                  "scrc",
-                  "scholars_studio",
-                  "success_center",
-                  "ask_a_librarian",
-                  "asrs",
-                  "guest_computers"
-                ]
-      },
-      {
-        slug: "ginsburg",
-        spaces: ["ginsburg", "innovation"]
-      },
-      {
-        slug: "podiatry",
-        spaces: ["podiatry"]
-      },
-      {
-        slug: "ambler",
-        spaces: ["ambler"]
-      },
-      {
-        slug: "blockson",
-        spaces: ["blockson"]
-      }
-    ]
     @buildings.each do |building|
-      building.values.second.map! do |space|
-        space = [building.values.first, LibraryHour.where(location_id: space, date: @monday..@sunday + 1)]
+      building[:spaces].map! do |space|
+        space = [building[:slug], LibraryHour.where(location_id: space, date: @monday..@sunday + 1)]
       end
     end
   end
@@ -60,18 +28,39 @@ class LibraryHoursController < ApplicationController
     end
   end
 
-  def set_location
-    @location = Building.where(hours: params[:id])
-    if @location.blank?
-      @location = Space.where(hours: params[:id])
-    end
-    if @location.blank?
-      @location = Service.where(hours: params[:id])
-    end
-  end
-
-  def get_locations
-    @location = LibraryHour.distinct.pluck(:location_id)
+  def buildings
+    @buildings = [
+      {
+        slug: "ambler",
+        spaces: ["ambler"]
+      },
+      {
+        slug: "blockson",
+        spaces: ["blockson"]
+      },
+      {
+        slug: "charles",
+        spaces: [
+                  "charles",
+                  "service_zone",
+                  "cafe",
+                  "scrc",
+                  "scholars_studio",
+                  "success_center",
+                  "ask_a_librarian",
+                  "asrs",
+                  "guest_computers"
+                ]
+      },
+      {
+        slug: "ginsburg",
+        spaces: ["ginsburg", "innovation"]
+      },
+      {
+        slug: "podiatry",
+        spaces: ["podiatry"]
+      }
+    ]
   end
 
   def build_hours_data_structure(input)

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -8,6 +8,7 @@ class Building < ApplicationRecord
   include SetDates
   include Categorizable
   include Imageable
+  include HasHours
   require "uploads"
 
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true

--- a/app/models/concerns/has_hours.rb
+++ b/app/models/concerns/has_hours.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module HasHours
+  extend ActiveSupport::Concern
+
+  def get_hours
+    LibraryHour.where(location_id: self.hours, date: monday..sunday)
+  end
+
+  def get_child_hours
+    self.spaces.where.not(hours: nil).map do |location|
+      space = [location.label, location.get_hours]
+    end
+  end
+
+  def monday(date_param = nil)
+    date_param ? date_param.beginning_of_week : Date.today.beginning_of_week
+  end
+
+  def sunday(date_param = nil)
+    date_param ? date_param.end_of_week + 1 : Date.today.end_of_week + 1
+  end
+end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -8,6 +8,7 @@ class Space < ApplicationRecord
   include SetDates
   include Categorizable
   include Imageable
+  include HasHours
   has_ancestry
 
   validates :name, presence: true

--- a/app/views/admin/categories/show.html.erb
+++ b/app/views/admin/categories/show.html.erb
@@ -1,0 +1,77 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+  <% if Rails.application.routes.url_helpers.method_defined?(page.resource.class.name.downcase + "_path") %>
+  <div>
+    <%= link_to(t("manifold.admin.actions.show_website"), page.resource, class: "button green")  %>
+  </div>
+  <% end %>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          <%= render_field attribute, page: page %></dd>
+    <% end %>
+    <dt class="attribute-label" id="Entites">
+      Entities
+    </dt>
+    <dd class="attribute-data attribute-data--entities">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>Class</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% page.resource.items.each do |item| %>
+            <%= tag.tr do %>
+              <%= tag.td(item.label, class: "item-label") %>
+              <%= tag.td(item.class, class: "item-class") %>
+              <%= tag.td(link_to("Show", ["admin", item], class: "button")) %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    </dd>
+  </dl>
+</section>

--- a/app/views/admin/library_hours/index.html.erb
+++ b/app/views/admin/library_hours/index.html.erb
@@ -45,15 +45,15 @@ It renders the `_table` partial to display details about the resources.
 
 <section class="main-content__body main-content__body--flush">
   <div class="container" style="padding-left: 2rem;">
-    <div id="last-sync">
-      <p>Last Library Hours Sync: 
-        <%= @last_sync.updated_at.in_time_zone.strftime("%m/%e/%Y %l:%M %p") %>
-      </p>
-    </div>
+    <% unless @last_sync.nil? %>
+      <div id="last-sync">
+        <p>Last Library Hours Sync: 
+          <%= @last_sync.updated_at.in_time_zone.strftime("%m/%e/%Y %l:%M %p") %>
+        </p>
+      </div>
+    <% end %>
 
     <%= link_to "Library Hours Public Page", hours_path  %>
-
-
 
   </div>
 </section>

--- a/app/views/buildings/_show_hours.html.erb
+++ b/app/views/buildings/_show_hours.html.erb
@@ -1,0 +1,106 @@
+<div class="current-week">
+
+  <div class="row"> <!-- dates header -->
+    <div class="col-3"><h2>Weekly Hours</h2></div>
+    <div class="col-md-9 text-right">
+      <%= link_to "See More Hours for this location", {controller: :library_hours, action: :index}, class: "today_button"  %>
+    </div>
+
+
+    </div>
+  </div>
+  <div class="row hours-header">
+      <div class="col-3">
+        <span class="month hours-month-name">
+          <%= @today.to_date.strftime("%B %Y") %>
+        </span>
+      </div>
+
+      <div class="col-9">
+        <div class="row">
+
+        <% 7.times do |date| %>
+          <% if @building.monday.to_date+date == @today.to_date %>
+            <div class="col hours-dates today day-of-week text-center">
+          <% else %>
+            <div class="col hours-dates text-center">
+          <% end %>
+
+              <%= (@building.monday.to_date+date).strftime("%a %d") %> 
+
+            </div>
+        <% end %>
+      </div>
+      </div>
+   </div>
+
+    <div class="row" style="margin-top: 14px;"> <!-- location -->
+
+      <div class="col-3 text-right"> 
+        <h3>
+          <%= location_name(@building.hours) %>
+        </h3>
+      </div>
+
+      <div class="col-9">
+        <div class="row">
+        <% @building.get_hours.each_with_index do |time,index| %> <!-- hours -->
+
+          <% if @building.monday.to_date+index == @today.to_date %>
+            <div class="col today">
+            <% else %>
+            <div class="col">
+          <% end %>
+
+            <% if time.hours.downcase == "closed" %>
+              <span class="closed"><%= time.hours %></span>
+            <% else %>
+              <%= time.hours %>
+            <% end %>
+
+            </div>
+
+        <% end %> <!-- hours -->
+        </div>
+      </div>
+
+    </div> <!-- location -->
+
+    <% @building.get_child_hours.sort.each do |space| %>
+    <% unless space[0].blank? || space[1].blank? %>
+
+      <div class="row" style="margin-top: 14px;"> <!-- space-location -->
+
+        <div class="col-3 text-right"> 
+          <h3>
+            <%= space[0] %>
+          </h3>
+        </div>
+
+        <div class="col-9">
+          <div class="row">
+          <% space[1].each_with_index do |time,index| %> <!-- hours -->
+
+            <% if @building.monday.to_date+index == @today.to_date %>
+              <div class="col today">
+              <% else %>
+              <div class="col">
+            <% end %>
+
+              <% if time.hours.downcase == "closed" %>
+                <span class="closed"><%= time.hours %></span>
+              <% else %>
+                <%= time.hours %>
+              <% end %>
+
+              </div>
+
+          <% end %> <!-- hours -->
+          </div>
+        </div>
+
+      </div> <!-- space-location -->
+      <% end %>
+    <% end %>
+
+</div>

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -25,33 +25,8 @@
   </div>
 </div>
 
-<div class="row d-none d-xl-block">
+<div class="row d-none d-lg-block">
   <div class="col">
-    <%= render "spaces" %>
-  </div>
-</div>
-<div class="row d-block d-xl-none">
-  <div class="col">
-    <%= render "buildings/responsive/spaces" %>
-  </div>
-</div>
-<!-- <div class="row d-none d-xl-block">
-  <div class="col">
-    <%# render "collections" %>
-  </div>
-</div>
-<div class="row d-block d-xl-none">
-  <div class="col">
-    <%# render "buildings/responsive/collections" %>
-  </div>
-</div> -->
-<div class="row d-none d-xl-block">
-  <div class="col">
-    <%= render "visit" %>
-  </div>
-</div>
-<div class="row d-block d-xl-none">
-  <div class="col">
-    <%= render "buildings/responsive/visit" %>
+    <%= render "show_hours" %>
   </div>
 </div>

--- a/app/views/library_hours/show.html.erb
+++ b/app/views/library_hours/show.html.erb
@@ -1,57 +1,96 @@
-<div class="row">
-  <div class="col breadcrumbs">
-    <%= link_to "Home", root_path.to_s %> 
-    <%= link_to "Hours", controller: 'library_hours', action: :index %> 
-    <%= @location.first.name %>
-  </div>
-</div>
-<div class="row">
-  <div class="col">
-    <div class="vertical-stripes-sm">
-      <h2><span><%= @location.first.name %> Hours</span></h2>
+<%# binding.pry %>
+<div class="current-week">
+	<% @buildings.each do |location| %>
+  <% if location[:slug] == @location %>
+
+  <div class="row"> <!-- dates header -->
+    <div class="col-3"><h2>Weekly Hours</h2></div>
+    <div class="col-9 text-right">
+       <div class="col-md-6 text-center date-range">
+
+      <%= link_to "<-", {controller: :library_hours, action: "show", slug: location[:slug], date: @last_week} %> 
+
+      <%= @monday.strftime("%b %d, %Y") unless @monday.nil? %> - <%= @sunday.strftime("%b %d, %Y") unless @sunday.nil? %>
+     
+      <%= link_to "->", {controller: :library_hours, action: "show", slug: location[:slug], date: @next_week} %>
+
+      </div>
+
+      <div class="col-md-6 text-center">
+        <%= link_to "Go to Today", {controller: :library_hours, action: :show, id: location[:slug]}, class: "today_button"  %>
+      </div>
     </div>
   </div>
-</div>
-<h2>Current Week</h2>
-<div class="row current-week">
-	<% @seven.each do |hour| %>
-		<div class="col col-sm-2">
-			<% if hour.date.to_date == @today %>
-			<span class="today">Today</span><br/>
-			<% else %>
-				<strong><%= hour.date.strftime("%A") %></strong><br/>
-			<% end %>
-			<%= hour.hours %>
-		</div>
-	<% end %>
-</div>
+  <div class="row" style="margin-top: 35px;">
+      <div class="col-3">
+        <span class="month" style="font-weight: 600;font-size: 175%"><%= @today.strftime("%B %Y") %></span>
+      </div>
 
-<table>
-  <thead>
-    <tr>
-      <th>Date</th>
-      <th>Hours</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
+      <div class="col-9">
+        <div class="row">
 
-  <tbody>
-    <% @hours.each do |hour| %>
-      <% unless hour.date.to_date < @today %>
-      <tr>
-        <td>
-          <% if(hour.date.to_date) %>
-            <%= hour.date.strftime("%A, %B %d, %Y") %>
+        <% 7.times do |date| %>
+          
+          <% if @monday+date == @today %>
+            <div class="col hours-dates today day-of-week text-center">
           <% else %>
-            <%= hour.date %>
+            <div class="col hours-dates text-center">
           <% end %>
-        </td>
-        <td><%= hour.hours %></td>
-      </tr>
-    <% end %>
-    <% end %>
-  </tbody>
-</table>
 
-<br>
+              <%= (@monday+date).strftime("%a %d") %> 
 
+            </div>
+        <% end %>
+      </div>
+      </div>
+   </div>
+
+    <% unless location.values.second.first.second.empty? %>
+
+
+    <% location.values.second.each do |hours| %>
+        <div class="row" style="margin-top: 14px;"> <!-- location -->
+
+          <div class="col-3 text-right"> 
+            <h3>
+              <%= location_name(hours.second.first.location_id) %>
+            </h3>
+          </div>
+
+          <div class="col-9">
+            <div class="row">
+            <% hours.second.each_with_index do |time,index| %> <!-- hours -->
+
+              <% if @monday+index == @today %>
+                <div class="col today">
+                <% else %>
+                <div class="col">
+              <% end %>
+
+                <% if time.hours.downcase == "closed" %>
+                  <span class="closed"><%= time.hours %></span>
+                <% else %>
+                  <%= time.hours %>
+                <% end %>
+
+                </div>
+
+            <% end %> <!-- hours -->
+          </div>
+        </div>
+
+        </div>
+      <% end %>
+
+
+    <% else %> <!-- unless -->
+      <div class="row" style="margin-top: 14px;">
+        <div class="col-12 text-center">
+          <h3>No data for current date range</h3>
+        </div>
+      </div> 
+    <% end %>
+
+  <% end %>
+<% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,39 @@ module Tude
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.building_spaces = [
+      {
+        slug: "ambler",
+        spaces: ["ambler"]
+      },
+      {
+        slug: "blockson",
+        spaces: ["blockson"]
+      },
+      {
+        slug: "charles",
+        spaces: [
+                  "charles",
+                  "service_zone",
+                  "cafe",
+                  "scrc",
+                  "scholars_studio",
+                  "success_center",
+                  "ask_a_librarian",
+                  "asrs",
+                  "guest_computers"
+                ]
+      },
+      {
+        slug: "ginsburg",
+        spaces: ["ginsburg", "innovation"]
+      },
+      {
+        slug: "podiatry",
+        spaces: ["podiatry"]
+      }
+    ]
+
     config.group_types = ["Assembly",
                           "Committee",
                           "Department",


### PR DESCRIPTION
Please create the ability to display relevant hours in both the building and space entities. The design for the building page is in MAN‌-344 . Jackie Sipes is still working on the wireframe for the space entity display. However, it should look the same as the building display page.

This should be a widget/helper that can be dropped into any entity display page that has hours tracked in the spreadsheet.

****************************************

Add hours logic to to concern, has_hours
create model partial for hours display, currently building only
Extended formatting not included in this ticket as it will be applied through the model's views.
