### PR TITLE
#MAN-358 Tablet view - remove the search box from the header

### DIFF
--- a/app/assets/stylesheets/partials/_searchbar.scss
+++ b/app/assets/stylesheets/partials/_searchbar.scss
@@ -190,6 +190,11 @@
 	background-color: $lightest-grey;
 	padding: 14px 0;
 }
+#mobile-search-container {
+	@media screen and (min-width: 768px) {
+		display: none!important;
+	}
+}
 
 #mobile-search.collapse {
 	height: 0;


### PR DESCRIPTION
If you stretch from mobile to tablet with the search open, the search box then displays twice. Can you remove the search box from the header and instead have the mobile search icon.

*******************
Adjusted overlap from bootstrap breakpoints to hide searchbar on page when searchbar in header becomes visible.