### PR TITLE
Shows a spaces index for json request only

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -5,6 +5,14 @@ class SpacesController < ApplicationController
   before_action :set_space, only: [:show]
   before_action :navigation_items, only: [:show]
 
+  def index
+    @spaces = Space.all
+    respond_to do |format|
+      format.html { render file: "#{Rails.root}/public/404.html", status: :not_found }
+      format.json { render json: SpaceSerializer.new(@spaces) }
+    end
+  end
+
   # GET /spaces/1
   # GET /spaces/1.json
   def show

--- a/spec/controllers/spaces_controller_spec.rb
+++ b/spec/controllers/spaces_controller_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe SpacesController, type: :controller do
 
   let(:space) { FactoryBot.create(:space) }
 
-  # describe "GET #index" do
-  #   it "returns http success" do
-  #     get :index
-  #     expect(response).to have_http_status(:ok)
-  #   end
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:not_found)
+    end
 
-  #   it "returns json when requested" do
-  #     get :index, format: :json
-  #     expect(response.header["Content-Type"]).to include "json"
-  #   end
-  # end
+    it "returns json when requested" do
+      get :index, format: :json
+      expect(response.header["Content-Type"]).to include "json"
+    end
+  end
 
   describe "GET #show" do
     it "returns http success" do


### PR DESCRIPTION
Issue: #MAN-379

- Provides all spaces for Solr harvest.
- JSON response to index json request.
- Raises 404 if an html request is made to the index action.