### PR TITLE
#MAN-286 Code Research Services Page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,6 @@ class PagesController < ApplicationController
     @events = Event.where("tags LIKE ?", "Health Sciences Libraries").take(4)
   end
 
-
   def about
     @categories = Category.find_by_name("About the Libraries").items.select { |item| item.class == Category }
   end
@@ -55,11 +54,6 @@ class PagesController < ApplicationController
 
   def research
     @categories = Category.find_by_name("Research Services").items.select { |item| item.class == Category }
-    @pages = Page.all
-    respond_to do |format|
-      format.html
-      format.json { render json: PageSerializer.new(@pages) }
-    end
   end
 
   def index

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -35,8 +35,10 @@ class Category < ApplicationRecord
   end
 
   def url(only_path: false)
-    if custom_url
+    if !custom_url.blank?
       custom_url
+    elsif items.first.class == ExternalLink
+      items.first.link
     elsif items.first
       polymorphic_url(items.first, only_path: only_path)
     else

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -47,8 +47,8 @@ as well as a link to its edit page.
       ) %>
       </dt>
 
-      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute, page: page %></dd>
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>">
+          <%= render_field attribute, page: page %></dd>
     <% end %>
   </dl>
     <%= render "select_version", page: page %>

--- a/app/views/admin/categories/show.html.erb
+++ b/app/views/admin/categories/show.html.erb
@@ -30,11 +30,6 @@ as well as a link to its edit page.
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
   </div>
-  <% if Rails.application.routes.url_helpers.method_defined?(page.resource.class.name.downcase + "_path") %>
-  <div>
-    <%= link_to(t("manifold.admin.actions.show_website"), page.resource, class: "button green")  %>
-  </div>
-  <% end %>
 </header>
 
 <section class="main-content__body">
@@ -47,7 +42,7 @@ as well as a link to its edit page.
       ) %>
       </dt>
 
-      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>">
           <%= render_field attribute, page: page %></dd>
     <% end %>
     <dt class="attribute-label" id="Entites">

--- a/app/views/pages/_categories.html.erb
+++ b/app/views/pages/_categories.html.erb
@@ -4,15 +4,15 @@
 
 	<div class="row">
 		<% @categories.each do |category| %>
-					
+
 			<div class="col-12 col-md-6 col-lg-4 text-center">
 				<% unless category.icon.attachment.nil? %>
-					<%= link_to (image_tag category.icon, class: "category-icon"), category.items.first %> 
+					<%= link_to (image_tag category.icon, class: "category-icon"), category_path(category) %> 
 				<% else %>
-					<%= link_to (image_tag "T-borderless.gif"), category.items.first %>
+					<%= link_to (image_tag "T-borderless.gif"), category_path(category) %>
 				<% end %>
-				<h2><%= link_to category.name, category.items.first %></h2>
-				<p><%= category.description unless category.description.blank? %></p>
+				<h2><%= link_to category.name, category_path(category) %></h2>
+				<p>internal<%= category.description unless category.description.blank? %></p>
 			</div>
 
 		<% end %>


### PR DESCRIPTION
- Removed serialization from Research Services page as it belongs in the index method of the page controller
- Updated url method to provide link in cases where first item in category is an external link
- Corrected malformed html in override of administrate's application show page
- Removed "show in website" button from overridden categories admin show page (they don't have their own pages)
- Updated links in category show page to use custom helper override category_path (for entities this returned either the link to the entity or the custom_url of a category AND now also will return the link from an external link if that is the first item in the category)