### PR TITLE
Error on linode when external link added to a space

### DIFF
--- a/app/views/application/_mobile-menu-items.html.erb
+++ b/app/views/application/_mobile-menu-items.html.erb
@@ -3,7 +3,7 @@
     <ul class="list-unstyled">
       <% @nav_items.flatten.uniq.each do |c| %>
         <li>
-          <%= link_to c.label, url_for(c) %>
+          <%= link_to c.label, category_url(c) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/buildings/_categories.html.erb
+++ b/app/views/buildings/_categories.html.erb
@@ -17,7 +17,7 @@
             <% else %>
             <li>
             <% end %>
-              <%= link_to c.label, url_for(c) %>
+              <%= link_to c.label, category_url(c) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/buildings/_mobile_categories.html.erb
+++ b/app/views/buildings/_mobile_categories.html.erb
@@ -3,7 +3,7 @@
     <ul class="list-unstyled">
       <% @nav_items.flatten.uniq.each do |c| %>
         <li>
-          <%= link_to c.label, url_for(c) %>
+          <%= link_to c.label, category_url(c) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/pages/_items.html.erb
+++ b/app/views/pages/_items.html.erb
@@ -18,7 +18,7 @@
               <% else %>
               <li>
               <% end %>
-                <%= link_to c.label, url_for(c) %>
+                <%= link_to c.label, category_url(c) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/services/_all_services.erb
+++ b/app/views/services/_all_services.erb
@@ -17,7 +17,7 @@
             <% else %>
             <li>
             <% end %>
-              <%= link_to c.label, url_for(c) %>
+              <%= link_to c.label, category_url(c) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/spaces/_all_spaces.html.erb
+++ b/app/views/spaces/_all_spaces.html.erb
@@ -18,7 +18,7 @@
             <% else %>
             <li>
             <% end %>
-              <%= link_to c.label, url_for(c) %>
+              <%= link_to c.label, category_url(c) %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Show page errors as it can't find external_link_path.

Updated call to entity_path for category items using custom category_url in routes.rb.