### PR TITLE
#MAN-388 "Internal" appears in category description 

### DIFF
--- a/app/views/pages/_categories.html.erb
+++ b/app/views/pages/_categories.html.erb
@@ -12,7 +12,7 @@
 					<%= link_to (image_tag "T-borderless.gif"), category_path(category) %>
 				<% end %>
 				<h2><%= link_to category.name, category_path(category) %></h2>
-				<p>internal<%= category.description unless category.description.blank? %></p>
+				<p><%= category.description unless category.description.blank? %></p>
 			</div>
 
 		<% end %>


### PR DESCRIPTION
The word "internal" appears in each of the category descriptions even though that word is not part of the description.

****************

Removed irrelevant text