### PR TITLE
Adds external_link_url route helper

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -21,12 +21,14 @@ class Category < ApplicationRecord
   # eg @category.items(limit_to: [:events]) would
   def items(limit_to: [], exclude: [])
     grouped = categorizations.group_by(&:categorizable_type)
-    unless limit_to.empty?
-      grouped.select! { |ct, _ | limit_to.include?(ct.downcase.to_sym)  }
+    if limit_to.present?
+      grouped.select! { |ct, _ | limit_to.include?(ct.underscore.to_sym)  }
     end
-    unless exclude.empty?
-      grouped.reject! { |ct, _ | exclude.include?(ct.downcase.to_sym)  }
+
+    if exclude.present?
+      grouped.reject! { |ct, _ | exclude.include?(ct.underscore.to_sym)  }
     end
+
     grouped.map do |type, objs|
       ids = objs.map(&:categorizable_id)
       type.constantize.find(ids)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,17 +94,17 @@ Rails.application.routes.draw do
 end
 
 Rails.application.routes.named_routes.url_helpers_module.module_eval do
-  def category_url(category, options={})
+  def category_url(category, options = {})
     category.url
   end
 
-  def external_link_url(external_link, options={})
+  def external_link_url(external_link, options = {})
     external_link.link
   end
 end
 
 Rails.application.routes.named_routes.path_helpers_module.module_eval do
-  def category_path(category, options={})
+  def category_path(category, options = {})
     category.path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,17 +94,17 @@ Rails.application.routes.draw do
 end
 
 Rails.application.routes.named_routes.url_helpers_module.module_eval do
-  def category_url(category)
+  def category_url(category, options={})
     category.url
   end
 
-  def external_link_url(external_link)
+  def external_link_url(external_link, options={})
     external_link.link
   end
 end
 
 Rails.application.routes.named_routes.path_helpers_module.module_eval do
-  def category_path(category)
+  def category_path(category, options={})
     category.path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   resources :pages, only: [:index, :show]
   resources :highlights, only: [:index, :show]
   resources :categories, only: [:show]
+  resources :external_link, only: [:show]
 
   get "forms", to: "forms#all"
   get "forms/*type", to: "forms#new"
@@ -95,6 +96,10 @@ end
 Rails.application.routes.named_routes.url_helpers_module.module_eval do
   def category_url(category)
     category.url
+  end
+
+  def external_link_url(external_link)
+    external_link.link
   end
 end
 

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -4,6 +4,8 @@
 FactoryBot.define do
   factory :category do
     name { "Dreaming" }
+    custom_url { "" }
+    description { "" }
 
     trait :custom_url do
       custom_url { "http://sand.man" }

--- a/spec/helpers/route_helpers_spec.rb
+++ b/spec/helpers/route_helpers_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Custom Route Helpers", type: :helper do
 
 
+  let(:link) { FactoryBot.create(:external_link) }
   let(:category) { FactoryBot.create(:category, name: "policy") }
   let(:policy) { FactoryBot.create(:policy) }
 
@@ -12,53 +13,24 @@ RSpec.describe "Custom Route Helpers", type: :helper do
     policy.categories << category
   end
 
+  describe "external_link_url" do
+      it "calls the external_link MOdel instance method #link" do
+          expect(link).to receive(:link)
+          external_link_url(link)
+        end
+    end
+
   describe "category_url" do
-    context "without a custom url" do
-      it "routes to first item" do
-        expect(category_url(category)).to match(/^http:\/\/test.host\/policies\/#{policy.id}/)
-      end
-    end
-
-    context "with a custom_url" do
-      let(:category) { FactoryBot.create(:category, :custom_url) }
-      it "routes to external url" do
-        expect(category_url(category)).to match(/http:\/\/sand.man/)
-      end
-    end
-
-    context "when no items are in the category" do
-      before do
-        policy.categories.each(&:destroy)
-      end
-
-      it "routes to the root url" do
-        expect(category_path(category)).to match(/^http:\/\/test.host\//)
-      end
+    it "calls the category Model instance method #url" do
+      expect(category).to receive(:url)
+      category_url(category)
     end
   end
 
   describe "category_path" do
-    context "without a custom_url" do
-      it "returns the path to the first item in the category" do
-        expect(category_path(category)).to match(/^\/policies\/#{policy.id}/)
-      end
-    end
-
-    context "with a custom_url" do
-      let(:category) { FactoryBot.create(:category, :custom_url) }
-      it "routes to external url" do
-        expect(category_path(category)).to match(/http:\/\/sand.man/)
-      end
-    end
-
-    context "when no items are in the category" do
-      before do
-        policy.categories.each(&:destroy)
-      end
-
-      it "routes to the root url" do
-        expect(category_path(category)).to match(/\//)
-      end
+    it "calls the category Model instance mathod #path" do
+      expect(category).to receive(:path)
+      category_path(category)
     end
   end
 end

--- a/spec/helpers/route_helpers_spec.rb
+++ b/spec/helpers/route_helpers_spec.rb
@@ -7,14 +7,10 @@ RSpec.describe "Custom Route Helpers", type: :helper do
 
   let(:link) { FactoryBot.create(:external_link) }
   let(:category) { FactoryBot.create(:category, name: "policy") }
-  let(:policy) { FactoryBot.create(:policy) }
 
-  before(:each) do
-    policy.categories << category
-  end
 
   describe "external_link_url" do
-      it "calls the external_link MOdel instance method #link" do
+      it "calls the external_link Model instance method #link" do
           expect(link).to receive(:link)
           external_link_url(link)
         end


### PR DESCRIPTION
Additionally, cleans up category url to ignore external_link items when generating a route.