### PR TITLE
#MAN-401 Remove "menu" from the category menus

### DIFF
--- a/app/views/buildings/_categories.html.erb
+++ b/app/views/buildings/_categories.html.erb
@@ -5,7 +5,7 @@
     <% else %>
       <div class="d-none d-lg-block index-category">
     <% end %>
-        <h2><%= cat.name %> menu</h2>
+        <h2><%= cat.name %></h2>
       </div>
 
     <div class="index-items">

--- a/app/views/services/_all_services.erb
+++ b/app/views/services/_all_services.erb
@@ -5,7 +5,7 @@
     <% else %>
       <div class="d-none d-lg-block index-category">
     <% end %>
-        <h2><%= cat.name %> menu</h2>
+        <h2><%= cat.name %></h2>
       </div>
 
     <div class="index-items">


### PR DESCRIPTION
Please remove the word "menu" from the secondary (category) menus on the left hand display.

This applies to both responsive and desktop view.

****************************

Removed the word 'menu' from side-menu titles. This only applied to buildings and services as they used the old style when they were coded.