### PR TITLE
#MAN-403 Bring forms pages up to current design standards

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -115,6 +115,12 @@ a:not(.dropdown-item) {
 		color: #903;
 	}
 }
+a.inline {
+	text-decoration: underline;
+}
+.back-button {
+	color: $red;
+}
 #content {
 	margin: 0;
 	background-color: $white;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,6 +1,7 @@
 @import "partials/_vars.scss";
 
 .form {
+	margin-top: 21px;
 	.radio_buttons {
 		.form-check {
 			display: inline-block;

--- a/app/views/forms/_all.html.erb
+++ b/app/views/forms/_all.html.erb
@@ -1,30 +1,24 @@
-<div class="row">
-  <div class="col breadcrumbs">
-    <%= link_to "Home", root_path.to_s %>
-    <%= link_to "Forms", forms_path %>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col">
-    <div class="vertical-stripes-sm">
-      <h1><span>Request Forms</span></h1>
-    </div>
-  </div>
-</div>
-
-<div class="container form">
   <div class="row">
-    <div class="col">
-      <p align="center" style="font-weight:600;margin-bottom:14px;">Use of these forms is intended for and restricted to members of the Temple University Community</p>
-      <p align="center" style="width:100%;margin:auto;"><a href="/contact">Library Suggestions/Feedback</a></p>
+    <div class="col-12 col-lg-9">
+
+      <div class="row">
+        <div class="col" style="padding-left: 0">
+          <h1>Request Forms</h1>
+        </div>
+      </div>
+    </div>
+
+  <div class="row">
+    <div class="col text-center" style="font-size: larger;margin-bottom: 35px">
+      <p align="center">Use of these forms is intended for and restricted to members of the Temple University Community</p>
+      <p><a href="/contact-us">Library Suggestions/Feedback</a></p>
     </div>
   </div>
 
   <div class="row">
     <div class="col">
       <h2>Temple-owned materials</h2>
-      <ul>          
+      <ul class="list-unstyled">          
         <li>  
           <a href="/forms/missing-book">Missing Book Search Request</a>
         </li>
@@ -33,7 +27,7 @@
         </li>
       </ul>
       <h2>Instructional Services</h2>
-      <ul>          
+      <ul class="list-unstyled">          
         <li>  
           <a href="/forms/library-instruction">Request a Library Instruction Session</a>
         </li>
@@ -42,7 +36,7 @@
         </li>
       </ul>
       <h2>Library Privileges</h2>
-      <ul>          
+      <ul class="list-unstyled">          
         <li>  
           <a href="/forms/adjunct-privileges">Activate Adjunct Faculty Privileges (if not currently under contract)</a>
         </li>
@@ -60,13 +54,13 @@
         </li>
         </ul>
         <h2>Collection Development</h2>
-        <ul>
+        <ul class="list-unstyled">
           <li>  
             <a href="/forms/purchase-request">Request a Purchase for the Library Collections</a>
           </li>
         </ul>
         <h2>Administrative Services</h2>
-        <ul>
+        <ul class="list-unstyled">
           <li>  
             <a href="/forms/filming-request">Guidelines for Requesting Permission to Use the Libraries for Filming</a>
           </li>
@@ -79,13 +73,13 @@
         </ul>  
 
         <h2>Requesting books and journal articles owned by Temple</h2>
-        <ul>
+        <ul class="list-unstyled">
           <li>  
             You can request books and journal articles from other Temple campuses and Remote Storage. To do so, <a class="inline" href="https://librarysearch.temple.edu/users/account">log in to the Library Search</a>, locate the item's record in the Library Search, and click on the <strong>Request</strong> button. 
           </li>
         </ul>   
         <h2>Temple doesn't have it?</h2>
-        <ul>
+        <ul class="list-unstyled">
           <li>
             The best place to request books that Temple doesn't own is through <a class="inline" href="https://e-zborrow.relaisd2d.com/gateway/TEMPLE.html">E-ZBorrow</a>.
           </li>
@@ -94,9 +88,12 @@
           </li>
         </ul>   
         <h2>Other Forms</h2>
-        <ul>
+        <ul class="list-unstyled">
           <li>
-            <a href="/forms/3d-printing">3D Printing Request Form</a></span><br><span><a href="/forms/staff/">Library Staff Forms -- Staff Use Only</a>
+            <a href="/forms/3d-printing">3D Printing Request Form</a>
+          </li>
+          <li>
+            <a href="/forms/staff/">Library Staff Forms -- Staff Use Only</a>
           </li>
         </ul>
   </div>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,56 +1,58 @@
-<% unless @type.nil? || @type == "all" %>
-<div class="row">
-  <div class="col breadcrumbs">
-    <%= link_to "Home", root_path.to_s %>
-    <%= link_to "Forms", forms_path  %>
-    <%= render "forms/#{@type}/title" %>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col">
-    <div class="vertical-stripes-sm">
-      <h1><span><%= render "forms/#{@type}/title" %></span></h1>
-    </div>
-  </div>
-</div>
-
 <div class="container form">
+  <% unless @type.nil? || @type == "all" %>
+
   <div class="row">
-    <div class="col">
-      <%= render "forms/#{@type}/intro" %>
+    <div class="col-12 col-lg-9">
+
+      <div class="row">
+        <div class="col back-button">
+          < <%= link_to "View all forms", forms_path, class: "inline" %>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col">
+            <h1><%= render "forms/#{@type}/title" %></h1>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col">
+          <%= render "forms/#{@type}/intro" %>
+        </div>
+      </div>
+
+      <%= simple_form_for @form, html: {class: "form-vertical" } do |f| %>
+      <%= f.input :form_type, as: :hidden, input_html: { value: "#{@type}" } %>
+
+      <% unless @type == "ir" %>
+        <div class="row">
+          <div class="col">
+            <fieldset style="border: solid #ccc 2px;padding: 21px;border-radius:7px;margin-bottom: 35px;">
+              <legend style="width: auto;padding: 0 21px;">Your Information</legend>
+            <%= render "forms/shared/personal_info", f: f %>
+            </fieldset>
+          </div>
+        </div>
+      <% end %>
+
+        <div class="row">
+          <div class="col">
+            <fieldset style="border: solid #ccc 2px;padding: 21px;border-radius:7px;">
+              <legend style="width: auto;padding: 0 21px;">Request Information -- Please do not abbreviate</legend>
+              <%= render "forms/#{@type}/request-info", f: f %>
+          </div>
+        </div>
+
+        <div class="row" style="margin-top: 28px;">
+          <div class="col">
+            <%= f.button :submit, 'Send Request', class: "btn btn-primary" %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
-
-  <%= simple_form_for @form, html: {class: "form-vertical" } do |f| %>
-  <%= f.input :form_type, as: :hidden, input_html: { value: "#{@type}" } %>
-
-  <% unless @type == "ir" %>
-    <div class="row">
-      <div class="col">
-        <fieldset style="border: solid #ccc 2px;padding: 21px;border-radius:7px;margin-bottom: 35px;">
-          <legend style="width: auto;padding: 0 21px;">Your Information</legend>
-        <%= render "forms/shared/personal_info", f: f %>
-        </fieldset>
-      </div>
-    </div>
-  <% end %>
-
-    <div class="row">
-      <div class="col">
-        <fieldset style="border: solid #ccc 2px;padding: 21px;border-radius:7px;">
-          <legend style="width: auto;padding: 0 21px;">Request Information -- Please do not abbreviate</legend>
-          <%= render "forms/#{@type}/request-info", f: f %>
-      </div>
-    </div>
-
-    <div class="row" style="margin-top: 28px;">
-      <div class="col">
-        <%= f.button :submit, 'Send Request', class: "btn btn-primary" %>
-      </div>
-    </div>
+  <% else %>
+    <%= render "all" %>
   <% end %>
 </div>
-<% else %>
-  <%= render "all" %>
-<% end %>

--- a/app/views/forms/recall-book/_intro.html.erb
+++ b/app/views/forms/recall-book/_intro.html.erb
@@ -1,7 +1,7 @@
-<div style="font-size: 1.5rem;margin-bottom: 2.5rem;" class="text-center">(Faculty/Library Staff only)</div>
-<div style="line-height: 1.75rem;margin-left: 5%">
+<div style="font-size: 1.5rem;margin-bottom: 2.5rem;">(Faculty/Library Staff only)</div>
+<div style="line-height: 1.15rem;">
 	<p>When you recall a book, the person who has it checked out has two weeks to return it.</p>
-	<p>Try <%= link_to "E-ZBorrow", "https://e-zborrow.relaisd2d.com/gateway/TEMPLE.html", style: "text-decoration-line: underline; font-size: 14.4px;" %> instead. Books generally arrive in three to five days.</p>
+	<p>Try <%= link_to "E-ZBorrow", "https://e-zborrow.relaisd2d.com/gateway/TEMPLE.html" %> instead. Books generally arrive in three to five days.</p>
 	<p>One request per form. You must complete the form again for another request.</p>
 	<p>Only recall requests submitted by current Temple University staff and faculty will be reviewed.</p>
 </div>


### PR DESCRIPTION
Removed old styles. Kept forms to 9 columns, 3 empty to the right.