### PR TITLE
Events feed from Drupal

### DIFF
--- a/app/controllers/concerns/event_filters.rb
+++ b/app/controllers/concerns/event_filters.rb
@@ -23,7 +23,6 @@ module EventFilters
         end
       end }
 
-    locations.reject! { |s| s.nil? }
-    locations.uniq.sort
+    locations.reject! { |s| s.nil? }.compact.uniq.sort
   end
 end

--- a/app/controllers/concerns/event_filters.rb
+++ b/app/controllers/concerns/event_filters.rb
@@ -18,9 +18,12 @@ module EventFilters
       unless event.building.nil?
         event.building.label
       else
-        event.external_building
+        unless event.external_building.nil?
+          event.external_building
+        end
       end }
 
+    locations.reject! { |s| s.nil? }
     locations.uniq.sort
   end
 end

--- a/app/controllers/concerns/event_filters.rb
+++ b/app/controllers/concerns/event_filters.rb
@@ -23,6 +23,6 @@ module EventFilters
         end
       end }
 
-    locations.reject! { |s| s.nil? }.compact.uniq.sort
+    locations.compact.uniq.sort
   end
 end


### PR DESCRIPTION
Added logic to filter helper where locations are not supplied from old events in Drupal to ignore the nils.