### PR TITLE
MAN-434 left hand menu styling

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -122,9 +122,6 @@
   padding: 21px;
   margin-bottom: 14px;
 }
-.leftside-index {
-	background-color: transparent!important;
-}
 .register-link {
 		background-color: $foamgreen;
 		padding: 21px;
@@ -139,7 +136,6 @@
 		}
 }
 .events_facets {
-	background-color: $lightest-grey;
 	padding-bottom: 21px;
 
 	.events_search {
@@ -189,9 +185,13 @@
 	}
 	.event_types, .event_spaces {
 		.active {
-			background-color: $white;
+			background-color: $seagreen;
+			color: $white;
 			margin-left: 4px;
 			padding-left: 14px;
+			a {
+				color: $white;
+			}
 		}
 	}
 	.filter-reset {

--- a/app/assets/stylesheets/persons.scss
+++ b/app/assets/stylesheets/persons.scss
@@ -26,8 +26,12 @@
 			}
 		}
 		li.active {
-			background-color: $white;
+			background-color: $seagreen;
+			color: $white;
 			margin-left: 4px;
+			a {
+				color: $white;
+			}
 		}
 	}
 	a[data-toggle="collapse"]:after {
@@ -193,6 +197,6 @@
 	display:inline-block;
 	float: right;
 	a {
-		color: $black!important;
+		color: $white!important;
 	}
 }

--- a/app/assets/stylesheets/services.scss
+++ b/app/assets/stylesheets/services.scss
@@ -5,7 +5,6 @@
 }
 
 .leftside-index {
-	background-color: $lightest-grey;
 	width: 95%;
 	@media (max-width: 950px) {
 		width: 100%;


### PR DESCRIPTION
1. Events index page - remove grey background from filtering
2. On events index, staff directory and finding aids index, highlight filters with a green background and white text similar to how menu items are highlighted in the left hand nav menus. 

3. For all index lists (staff directory, finding aids, events), highlight selected filter with green background as we do with the left hand nav. Also keep the X.

*************************

Removed grey backing on left-side of events index, staff directory and finding aids indexes, Replaced white active selection color with green and orresponding whte text. X deslect link also changed to white.