### PR TITLE
#MAN-445 Update Library Hours desktop and mobile

### DIFF
--- a/app/views/library_hours/index.html.erb
+++ b/app/views/library_hours/index.html.erb
@@ -1,10 +1,9 @@
-<div class="container hours">
-
 <div class="row date-nav">
+  <div class="container">
+    <div class="row">
   <div class="col-12 col-lg-3">
     <h1 class="page-title">Library Hours</h1>
   </div>
-
   <div class="col-12 col-lg-4 text-lg-center date-range">
       <%= link_to "<-", {controller: :library_hours, action: "index", date: @last_week} %> 
       <%= @monday.strftime("%b %d, %Y") unless @monday.nil? %> - <%= @sunday.strftime("%b %d, %Y") unless @sunday.nil? %>
@@ -14,13 +13,17 @@
     <%= link_to "Go to this week", {controller: :library_hours, action: :index}, class: "today_button" %>
   </div>
 </div>
-
-<div class="buildings d-none d-lg-block">
-  <%= render "desktop" %>
+</div>
 </div>
 
-<div class="buildings d-block d-lg-none">
-  <%= render "mobile" %>
-</div>
+<div class="container hours">
+
+  <div class="buildings d-none d-lg-block">
+    <%= render "desktop" %>
+  </div>
+
+  <div class="buildings d-block d-lg-none">
+    <%= render "mobile" %>
+  </div>
 
 </div>


### PR DESCRIPTION
I have just one request: can you make the grey behind “library hours” extend to the width of the screen (on desktop)? That’s all!

************************

Adjusted grey bar to 100% outside of container.