### PR TITLE
Don't display ordered pages in administrate

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -8,5 +8,11 @@ module Admin
       flash[:notice] = "Document purged"
       redirect_to admin_page_path
     end
+
+    def order
+      @order ||= Administrate::Order.new(
+        nil, nil
+      )
+    end
   end
 end


### PR DESCRIPTION
- Fixes an error thrown when attempting to visit pages administrate
  index view after the first page.  There is a conflict between
  the page object and pagination pages in the administrate params
  passed to the controller order method.  To avoid this problem,
  we will bypass the ability to order pages in the administrate
  index view.