### PR TITLE
#MAN-439 Update blog links on DSC homepage

### DIFF
--- a/app/views/pages/tudsc.html.erb
+++ b/app/views/pages/tudsc.html.erb
@@ -96,9 +96,9 @@
 					<h2>Research Blog</h2>
 					<ul class="list-unstyled">
 						<% @blog_posts.each do |link| %>
-							<li><%= link_to link.title, link %></li>
+							<li><%= link_to link.title, link.post_guid %></li>
 						<% end %>
-						<li class="text-right dsc-event"><%= link_to "View all", blog_path(@blog), style: "text-decoration:underline" %> ></li>
+						<li class="text-right dsc-event"><%= link_to "View all", strip_tags(@blog.base_url), style: "text-decoration:underline" %> ></li>
 					</ul>
 				</div>
 				<div class="dsc-links d-block d-lg-none">


### PR DESCRIPTION
Please link the blog posts to the individual post on the home blog (sites.temple.edu/dsc/…), not a show page within the CMS.

Please link the “View all” in the blogs to the homepage of the blog in sites (sites.temple.edu/dsc), not the show page in the CMS