### PR TITLE
fixing travis deploy scripts for stage + prod to use master, diff git dirs.

### DIFF
--- a/.travis/deploy-prod.sh
+++ b/.travis/deploy-prod.sh
@@ -3,8 +3,8 @@ set -e
 
 cd ..
 # clone deployment playbook
-git clone --single-branch --branch qa git@github.com:tulibraries/ansible-playbook-manifold.git
-cd ansible-playbook-manifold
+git clone --single-branch --branch master git@github.com:tulibraries/ansible-playbook-manifold.git manifold-prod
+cd manifold-prod
 # install playbook requirements
 sudo pip install pipenv
 # install playbook requirements

--- a/.travis/deploy-stage.sh
+++ b/.travis/deploy-stage.sh
@@ -3,8 +3,8 @@ set -e
 
 cd ..
 # clone deployment playbook
-git clone --single-branch --branch qa git@github.com:tulibraries/ansible-playbook-manifold.git
-cd ansible-playbook-manifold
+git clone --single-branch --branch master git@github.com:tulibraries/ansible-playbook-manifold.git manifold-stage
+cd manifold-stage
 # install playbook requirements
 sudo pip install pipenv
 # install playbook requirements


### PR DESCRIPTION
Unlike, travis doesn't atm support manual approval for the prod deploy, but it at least waits until stage deploys /shrug