### PR TITLE
Add import back in for partials while keeping require statements intact.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,7 +47,7 @@ $sizes: map-merge(
 @import "bootstrap";
 @import "bootstrap/functions";
 @import "bootstrap/variables";
-@import "partials/_vars.scss";
+@import "partials/*";
 @import "font-awesome";
 
 


### PR DESCRIPTION
This picks up the color variables and does not change the layout as it did when the requires were removed.