### PR TITLE
#MAN-478 Update Books & Media link on homepage

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,7 +51,7 @@
 			<div class="col-12 col-lg-3 catalog-search h-auto">
 				<div class="h-30 square">
 					<%= image_tag "book_white.png", class: "icon" %>
-					<%= link_to "Books & Media", "http://librarysearch.temple.edu/books" %>
+					<%= link_to "Books & Media", "http://librarysearch.temple.edu/catalog" %>
 				</div>
 				<div div class="h-30 square">
 					<%= image_tag "magazine_white.png", class: "icon" %>


### PR DESCRIPTION
Please update the link to "Books & Media" button on the main homepage:

Books & Media" link should go to https://librarysearch.temple.edu/catalog, not https://librarysearch.temple.edu/catalog?f[format][]=Book
**********************
Updated link