### PR TITLE
All forms successfully emailed are persisted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem "pg"
 # Gemfile
 gem "rswag-api"
 gem "rswag-ui"
+gem "lockbox"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lockbox (0.2.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -573,6 +574,7 @@ DEPENDENCIES
   json-schema
   kaminari
   listen (>= 3.0.5, < 3.2)
+  lockbox
   mail_form
   mini_magick (~> 4.9)
   mutant-rspec

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -42,9 +42,18 @@ class FormsController < ApplicationController
 
     if @form.deliver
       flash.now[:notice] = "Thank you for your message. We will contact you soon!"
+      persist_form!
     else
       flash.now[:error] = "Cannot send message."
       render :new
     end
+  end
+
+  def persist_form!
+    type = params[:form].delete(:form_type)
+    FormSubmission.create(
+      form_type: type,
+      form_attributes: params["form"]
+    )
   end
 end

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class FormSubmission < ApplicationRecord
+  serialize :form_attributes, JSON
+  encrypts :form_attributes
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,3 +54,4 @@ ENV["S3_ACCESS_KEY_ID"] = "access_key_id"
 ENV["S3_SECRET_ACCESS_KEY"] = "secret_access_key"
 ENV["S3_REGION"] = "region"
 ENV["S3_BUCKET"] = "bucket"
+ENV["LOCKBOX_MASTER_KEY"] = Lockbox.generate_key

--- a/db/migrate/20190725124948_create_form_submissions.rb
+++ b/db/migrate/20190725124948_create_form_submissions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateFormSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :form_submissions do |t|
+      t.text :form_attributes_ciphertext
+      t.string :form_type
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_141541) do
+ActiveRecord::Schema.define(version: 2019_07_25_124948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -234,6 +234,13 @@ ActiveRecord::Schema.define(version: 2019_07_19_141541) do
     t.datetime "updated_at", null: false
     t.string "drupal_id"
     t.index ["collection_id"], name: "index_finding_aids_on_collection_id"
+  end
+
+  create_table "form_submissions", force: :cascade do |t|
+    t.text "form_attributes_ciphertext"
+    t.string "form_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "group_contacts", force: :cascade do |t|

--- a/forms-readme.md
+++ b/forms-readme.md
@@ -71,3 +71,40 @@ and add the introductory text.
   ```
   attribute :cancellation_date
   ```
+
+## Form Persistence
+
+All form submissions are persisted to the database in the `form_submissions` table. As these forms can contain sensitive data, they are encrypted before they are stored in the DB, requiring the same key to decrypt. The key is picked up from `$LOCKBOX_MASTER_KEY` environment variable.
+
+
+## Testing Forms
+
+All Forms should be tested with the `email form` shared example.
+
+The `email form` shared example requires you to define two variables via `let`
+* `form_type` - the url path / template path of the form, like `missing-book`
+* `form_params` - a hash of params that represent data sent to the form when someone submits it. The `name` and `email` params are included by default; this just needs to include params specific to this form.
+
+
+`/spec/request/forms/recall_book_spec.rb`
+```
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Recall Book Form", type: :request do
+
+  let(:form_type) { "recall-book" }
+  let(:form_params) {
+    {
+      phone: "1234567890", tu_id: "test_id", department: "test dept",
+      affiliation: "Staff", author: "test author", title: "test title",
+      call_number: "test call number", substitute_edition: "false",
+      pickup_location: "Ambler"
+    }
+  }
+
+  it_behaves_like "email form"
+
+end
+```

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :form_submission do
+    form_type { "missing-book" }
+    form_attributes {
+      {
+        attribute1: "value 1",
+        attribute2: "value 2"
+      }
+    }
+  end
+end

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FormSubmission, type: :model do
+  let(:fs) { FactoryBot.create(:form_submission) }
+
+  describe "form_attributes" do
+    it "returns the data decrypted" do
+      expect(fs.form_attributes).to include(
+        "attribute1" => "value 1",
+        "attribute2" => "value 2"
+      )
+    end
+  end
+end

--- a/spec/requests/forms/ask_scrc_spec.rb
+++ b/spec/requests/forms/ask_scrc_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Ask SCRC Form", type: :request do
+
+  let(:form_type) { "ask-scrc" }
+  let(:form_params) {
+    {
+      phone: "1234567890", affiliation: "Staff", comments: "test comment"
+    }
+  }
+
+  it_behaves_like "email form"
+
+end

--- a/spec/requests/forms/missing_book_spec.rb
+++ b/spec/requests/forms/missing_book_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Missing Book Form", type: :request do
+
+  let(:form_type) { "missing-book" }
+  let(:form_params) {
+    {
+      phone: "1234567890", tu_id: "test_id", department: "test dept",
+      affiliation: "Staff", author: "test author", title: "test title",
+      call_number: "test call number"
+    }
+  }
+
+  it_behaves_like "email form"
+
+end

--- a/spec/requests/forms/recall_book_spec.rb
+++ b/spec/requests/forms/recall_book_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Recall Book Form", type: :request do
+
+  let(:form_type) { "recall-book" }
+  let(:form_params) {
+    {
+      phone: "1234567890", tu_id: "test_id", department: "test dept",
+      affiliation: "Staff", author: "test author", title: "test title",
+      call_number: "test call number", substitute_edition: "false",
+      pickup_location: "Ambler"
+      # Cencellation date doesn't appear in the email
+      #"cancellation_date(1i)" => "2019",
+      #"cancellation_date(2i)" => "25", "cancellation_date(3i)" => "1"
+    }
+  }
+
+  it_behaves_like "email form"
+
+end

--- a/spec/support/form_helper.rb
+++ b/spec/support/form_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.shared_examples "email form" do
+  before(:each) do
+    ActionMailer::Base.deliveries = []
+  end
+
+  let(:the_email) { ActionMailer::Base.deliveries.first }
+  let(:title) { I18n.t("manifold.default.forms.#{form_type.underscore}.title") }
+  let(:params) {  { params:
+      { form: {
+        form_type: form_type,
+        name: "test",
+        email: "test@example.com"
+      }.merge(form_params || {}) }
+      }
+    }
+
+  describe "" do
+    it "renders the form" do
+      get "/forms/#{form_type}"
+      expect(response).to render_template(:index)
+      expect(response.body).to include(title)
+    end
+
+    it "accepts information" do
+      post "/forms", params
+      expect(the_email.subject).to eq(title)
+      expect(the_email.body.raw_source).to include(*form_params.values)
+      # Check that after the email has been delivered, the
+      # form persists to the db. Hard to do in isolation
+      expect(FormSubmission.take.form_type).to eq(form_type)
+    end
+  end
+end


### PR DESCRIPTION
As form field vary greatly between form, we cannot persist them with a
column for each field. Instead we serialize as JSON the attributes into
`form_attributes`.

Because forms may contain sensitve data, we encrypt the form_attributes
before they are saved to the DB, and are decrypted on access via the
model, assuming  LOCKBOX_MASTER_KEY nev var value is the same it was at
the time of encryption.

This PR also adds some tests to a few forms to ensure the form renders,
can send email (in a test environment), and persists the submitted data
to the db. There are still several forms that require tests.

Blocked by https://github.com/tulibraries/ansible-playbook-manifold/pull/61