### PR TITLE
#MAN-389 Modify color of top nav to show page

### DIFF
--- a/app/assets/stylesheets/finding_aids.scss
+++ b/app/assets/stylesheets/finding_aids.scss
@@ -34,54 +34,7 @@
 }
 
 /* Index Page */
-ul {
-	margin-top: 10px;
-	li {
-		padding: 6px 14px;
-		padding-right: 7px;
-		font-size: 1rem;
-		a {
-			margin: 0 2px;
-			font-size: 1rem;
-		}
-	}
-	li.active {
-		background-color: $white;
-		margin-left: 4px;
-		padding-left: 14px;
-	}
-}
-a[data-toggle="collapse"]:after {
-	content: "\f105";
-  font-family: "FontAwesome";
-  font-size: larger;
-	float: right;
-	padding-right: 7px;
-}
-a[aria-expanded="true"]:after {
-	content: "\f107";
-  font-family: "FontAwesome";
-  font-size: larger;
-	float: right;
-	padding-right: 7px;
-}		
-.filter_reset {
-	margin-top: 21px;
-	padding-top: 14px;
-	border-top: solid $seagreen-dark 2px;
-}
-.aids-filter-reset {
-	width:50%;
-	background-color: $white;
-	text-align:center;
-	border: solid $seagreen 1px;
-	border-radius:4px;
-	padding: 7px;
-	margin: 21px auto;
-	a {
-		color: $seagreen!important;
-	}
-}
+
 .aid-index {
 	@media (max-width: 984px) {
 		margin-top: 14px;
@@ -93,5 +46,52 @@ a[aria-expanded="true"]:after {
 		padding: 0;
 		margin-bottom: 14px;
 	}
-
+	ul {
+		margin-top: 10px;
+		li {
+			padding: 6px 14px;
+			padding-right: 7px;
+			font-size: 1rem;
+			a {
+				margin: 0 2px;
+				font-size: 1rem;
+			}
+		}
+		li.active {
+			background-color: $white;
+			margin-left: 4px;
+			padding-left: 14px;
+		}
+	}
+	a[data-toggle="collapse"]:after {
+		content: "\f105";
+	  font-family: "FontAwesome";
+	  font-size: larger;
+		float: right;
+		padding-right: 7px;
+	}
+	a[aria-expanded="true"]:after {
+		content: "\f107";
+	  font-family: "FontAwesome";
+	  font-size: larger;
+		float: right;
+		padding-right: 7px;
+	}		
+	.filter_reset {
+		margin-top: 21px;
+		padding-top: 14px;
+		border-top: solid $seagreen-dark 2px;
+	}
+	.aids-filter-reset {
+		width:50%;
+		background-color: $white;
+		text-align:center;
+		border: solid $seagreen 1px;
+		border-radius:4px;
+		padding: 7px;
+		margin: 21px auto;
+		a {
+			color: $seagreen!important;
+		}
+	}
 }

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -68,6 +68,7 @@ a.donate {
 		display: inline-block;
 		position: relative;
 		top: 7px;
+		padding: 6px 14px;
 		img {
 			width: 36px;
 			height: 36px;

--- a/app/assets/stylesheets/partials/_mainmenu.scss
+++ b/app/assets/stylesheets/partials/_mainmenu.scss
@@ -22,8 +22,7 @@
 #main-menu {
 	background-color: $seagreen;
 	width: 100%;
-	margin-left: 0;
-	margin-right: 0;
+	margin: 14px 0 0 0;
 	height: auto;
 	display: inline-block;
 	position: relative;
@@ -39,14 +38,12 @@
 		padding-bottom: 0;
 		margin-bottom: 0;
 		li {
-			padding-top: .5rem;
-			padding-bottom: .5rem;
+			padding: .5rem 21px;
 			display: inline-block;
-			padding-left: 21px;
-			padding-right: 21px;
 			height: 100%;
 			vertical-align: middle;
-			border-left: solid $seagreen-dark 2px;
+			border-left: solid $seagreen 1px;
+			border-right: solid $seagreen 1px;
 			a {
 				color: $white;
 				font-size: 1.3rem;
@@ -56,26 +53,12 @@
 				}
 			}
 		}
-		li.first {
-			border-left: solid $seagreen-dark 0;
-			border-right: solid $seagreen-dark 0;
-		}
-		li.last {
-			border-right: solid $seagreen-dark 2px;
-			@media screen and (max-width: 1040px) {
-				border-right: solid $seagreen-dark 0;
-			}
-			@media screen and (max-width: 1039px) {
-				padding-right: 0;
-			}
-		}
 		li.nav-right {
 			@media screen and (min-width: 1040px) {
 				float: right;
 			}
 			background-color: $seagreen-dark;
 			padding-left: 49px;
-			border-color: $seagreen;
 			padding-right: 16px;
 		}
 		li.nav-right.hours-nav {
@@ -96,7 +79,18 @@
 		background-repeat: no-repeat;
 		background-size: 42px 42px;
 		}
-
+		li.active {
+			background-color: $black;
+			border: inset $white 1px;
+			border-top: 0;
+			border-bottom: 0;
+		}
+		#libchat_fe2bd0cb1f04720f51641c4f01b8e22e button {
+			background-color: transparent;
+			font-size: 1.3rem;
+			padding: 0;
+			border: 0;
+		}
 	}
 	.main-nav-right {
 		padding-left: 0;

--- a/app/assets/stylesheets/partials/_searchbar.scss
+++ b/app/assets/stylesheets/partials/_searchbar.scss
@@ -13,6 +13,7 @@
 		width: 100%;
 		ul {
 			margin-left: .65rem;
+			margin-top: .65rem;
 		}
 	}
 	form.mobile {
@@ -20,7 +21,6 @@
 	}
 	form {
 		width: 100%;
-		padding-top: 10px;
 		#librarySearch {
 			height: 42px;
 			font-size: 1.5rem;

--- a/app/views/application/_header_navbar.html.erb
+++ b/app/views/application/_header_navbar.html.erb
@@ -52,20 +52,20 @@
 
   <div class="row d-none d-sm-none d-md-none d-lg-block" id="main-menu">
     <div class="container nav-container">
-      <ul class="list-unstyled" style=""> 
-        <li class="first">
+      <ul class="list-unstyled "> 
+        <li class=" <% if action_name == 'about' %>active<% end %>">
           <%= link_to "About", pages_about_path %>
         </li>
-        <li>
+        <li class=" <% if action_name == 'visit' %>active<% end %>">
           <%= link_to "Visit & Study", pages_visit_path %>
         </li>
-        <li>
+        <li class=" <% if action_name == 'research' %>active<% end %>">
           <%= link_to "Research Services", pages_research_path %>
         </li>
-        <li class="last">
+        <li class=" <% if action_name == 'contact' %>active<% end %>">
           <%= link_to "Contact Us", pages_contact_path %>
         </li> 
-        <li class="nav-right hours-nav">
+        <li class="nav-right hours-nav <% if controller_name == 'library_hours' %>active<% end %>">
           <%= link_to "Hours", hours_path %>
         </li>
         <li class="nav-right chat-nav">


### PR DESCRIPTION
We want the top navigation to be highlighted when you're on one of those pages-- About, Visit & Study, etc... 

As a result, please make all of the navigation items the same green with the darker color vertical line separating each item. Then, when a user is on the top-level index page (About, Visit & Study, etc), that nav item will be highlighted using the darker green. However, when the user navigates to a sub-index page  from the top-level index page, all nav goes back to regular green. 

Remove all vertical lines in primary navigation.
*******************
Added checks for active page and highlighted corresponding menu item.