### PR TITLE
#MAN-415 Links not opening in a new window

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module Tude
         "a", "span", "bdo", "br", "em", "strong", "dfn", "code", "samp", "cite", "basefont",
         "font", "object", "param", "img", "table", "caption", "colgroup", "col", "thead", "tfoot", "tbody",
         "tr", "th", "td", "embed"]
+    config.action_view.sanitized_allowed_attributes = ["style", "href", "title", "target", "rel", "name",
+        "class", "title", "src", "height", "alt", "width", "colspan", "rowspan", "headers", "scope", "span"]
 
     config.generators do |g|
       g.test_framework :rspec, spec: true


### PR DESCRIPTION
I added links to https://web.qa.tul-infra.page/admin/pages/18 and set them to open in a new window. But when I click on the link in the live site, it still opens in the same window.
**************************
Added allowed attributes to global config.