### PR TITLE
#MAN-516 Remove Student Success Center from library hours

### DIFF
--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -46,7 +46,6 @@ class LibraryHoursController < ApplicationController
                   "cafe",
                   "scrc",
                   "scholars_studio",
-                  "success_center",
                   "ask_a_librarian",
                   "asrs",
                   "guest_computers"

--- a/app/services/sync_service/library_hours.rb
+++ b/app/services/sync_service/library_hours.rb
@@ -18,7 +18,6 @@ class SyncService::LibraryHours
                   { coordinates: "Sheet2!D2:D", slug: "cafe" },
                   { coordinates: "Sheet2!E2:E", slug: "scrc" },
                   { coordinates: "Sheet2!F2:F", slug: "scholars_studio" },
-                  { coordinates: "Sheet2!G2:G", slug: "success_center" },
                   { coordinates: "Sheet2!H2:H", slug: "ask_a_librarian" },
                   { coordinates: "Sheet2!I2:I", slug: "asrs" },
                   { coordinates: "Sheet2!J2:J", slug: "guest_computers" },


### PR DESCRIPTION
Removed Student Success Center form hours sync and display.