### PR TITLE
Add a redirect model and dashboard

### DIFF
--- a/app/controllers/admin/redirects_controller.rb
+++ b/app/controllers/admin/redirects_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Admin
+  class RedirectsController < Admin::ApplicationController
+  end
+end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -3,10 +3,11 @@
 class RedirectsController < ApplicationController
   def show
     if params[:path]
-      redirect = Redirect.find_by_legacy_path(params[:path])
+      path_with_slash = "/#{params[:path]}"
+      redirect = Redirect.find_by_legacy_path(path_with_slash)
       if redirect
         message =
-        "#{request.env['HTTP_HOST']}/#{params[:path]} has moved. \
+        "#{request.env['HTTP_HOST']}#{path_with_slash} has moved. \
         Please update bookmarks and links"
         redirect_to(redirect.path,
                     status: 301,

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RedirectsController < ApplicationController
+  def show
+    if params[:path]
+      redirect = Redirect.find_by_legacy_path(params[:path])
+      if redirect
+        message =
+        "#{request.env['HTTP_HOST']}/#{params[:path]} has moved. \
+        Please update bookmarks and links"
+        redirect_to(redirect.path,
+                    status: 301,
+                    notice: message
+                     )
+      else
+        raise ActionController::RoutingError.new("Not Found")
+      end
+    end
+  end
+end

--- a/app/dashboards/redirect_dashboard.rb
+++ b/app/dashboards/redirect_dashboard.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class RedirectDashboard < BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    legacy_path: Field::String,
+    manifold_path: Field::String,
+    redirectable: Field::Polymorphic.with_options(
+      classes: [
+        ::Building, ::Collection, ::Page,
+        ::Policy, ::Service, ::Space
+      ],
+      admin_only: true
+    ),
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    #:categorizations,
+    :legacy_path
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :legacy_path,
+    :manifold_path,
+    :redirectable,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :legacy_path,
+    :manifold_path,
+    :redirectable,
+  ].freeze
+
+  def display_resource(resource)
+    "#{resource.legacy_path}"
+  end
+end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -6,6 +6,8 @@ class Redirect < ApplicationRecord
 
   belongs_to :redirectable, polymorphic: true, optional: true
 
+  validates_uniqueness_of :legacy_path
+
   def path
     redirectable ? redirectable : manifold_path
   end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Redirect < ApplicationRecord
+  before_save :strip_starting_slash_in_legacy_path
+  before_save :manifold_path_cleanup!
+
+  belongs_to :redirectable, polymorphic: true, optional: true
+
+  def path
+    redirectable ? redirectable : manifold_path
+  end
+
+  def strip_starting_slash_in_legacy_path
+    if self.legacy_path.present?
+      self.legacy_path.gsub!(/^\//, "")
+    end
+  end
+
+
+  def manifold_path_cleanup!
+    strip_host_from_manifold_path!
+    ensure_starting_slash_in_manifold_path!
+  end
+
+  def ensure_starting_slash_in_manifold_path!
+    if self.manifold_path.present?
+      unless self.manifold_path.starts_with?("/")
+        self.manifold_path = self.manifold_path.prepend("/")
+      end
+    end
+  end
+
+  def strip_host_from_manifold_path!
+    if self.manifold_path.present?
+      self.manifold_path = URI.parse(self.manifold_path).path
+    end
+  end
+end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Redirect < ApplicationRecord
-  before_save :strip_starting_slash_in_legacy_path
+  before_save :ensure_starting_slash_in_legacy_path!
   before_save :manifold_path_cleanup!
 
   belongs_to :redirectable, polymorphic: true, optional: true
@@ -12,29 +12,23 @@ class Redirect < ApplicationRecord
     redirectable ? redirectable : manifold_path
   end
 
-  def strip_starting_slash_in_legacy_path
+  def ensure_starting_slash_in_legacy_path!
     if self.legacy_path.present?
-      self.legacy_path.gsub!(/^\//, "")
+      unless self.legacy_path.starts_with?("/")
+        self.legacy_path = self.legacy_path.prepend("/")
+      end
     end
   end
 
 
   def manifold_path_cleanup!
-    strip_host_from_manifold_path!
-    ensure_starting_slash_in_manifold_path!
-  end
-
-  def ensure_starting_slash_in_manifold_path!
     if self.manifold_path.present?
-      unless self.manifold_path.starts_with?("/")
-        self.manifold_path = self.manifold_path.prepend("/")
+      # make sure it is not a full url
+      unless self.manifold_path =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]
+        unless self.manifold_path.starts_with?("/")
+          self.manifold_path = self.manifold_path.prepend("/")
+        end
       end
-    end
-  end
-
-  def strip_host_from_manifold_path!
-    if self.manifold_path.present?
-      self.manifold_path = URI.parse(self.manifold_path).path
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -62,6 +62,26 @@
       "note": ""
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "75cc43dcda5755d4734e743e6fdfa9647192d58b93962aba7703e2a8f04e47ad",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/redirects_controller.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Redirect.find_by_legacy_path(\"/#{params[:path]}\").path, :status => 301, :notice => (\"#{request.env[\"HTTP_HOST\"]}#{\"/#{params[:path]}\"} has moved.         Please update bookmarks and links\"))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RedirectsController",
+        "method": "show"
+      },
+      "user_input": "Redirect.find_by_legacy_path(\"/#{params[:path]}\").path",
+      "confidence": "High",
+      "note": "External URLS are a valid redirect here"
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "7a8e4552d89bb53cf073729b06e4f1f6489e74f3657f7bc5f521e847f1e28b88",
@@ -111,26 +131,6 @@
       "user_input": null,
       "confidence": "High",
       "note": ""
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "82a17475735c24ddeb83fa1ab4501478ebeede7f7a2313d960571d3ae3b7ad3f",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/redirects_controller.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Redirect.find_by_legacy_path(params[:path]).path, :status => 301, :notice => (\"#{request.env[\"HTTP_HOST\"]}/#{params[:path]} has moved.         Please update bookmarks and links\"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RedirectsController",
-        "method": "show"
-      },
-      "user_input": "Redirect.find_by_legacy_path(params[:path]).path",
-      "confidence": "High",
-      "note": "Handled in the model before_save hooks"
     },
     {
       "warning_type": "Remote Code Execution",
@@ -256,6 +256,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-08-07 12:18:17 -0400",
+  "updated": "2019-08-07 14:30:00 -0400",
   "brakeman_version": "4.6.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -35,7 +35,7 @@
           "type": "controller",
           "class": "PersonsController",
           "method": "show",
-          "line": 37,
+          "line": 38,
           "file": "app/controllers/persons_controller.rb",
           "rendered": {
             "name": "persons/show",
@@ -58,37 +58,6 @@
         "template": "persons/_mobile"
       },
       "user_input": "Person.find(params[:id])",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "602e72340904f11e6395ddf2b08aab5c44c452fc61dcbb03657036d7b9d10d31",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/blogs/index.html.erb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(image_tag((Unresolved Model).new.custom_image(600, 264), :alt => \"\"), (Unresolved Model).new.link)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/blogs_controller.rb",
-          "rendered": {
-            "name": "blogs/index",
-            "file": "app/views/blogs/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blogs/index"
-      },
-      "user_input": "(Unresolved Model).new.link",
       "confidence": "Weak",
       "note": ""
     },
@@ -144,6 +113,26 @@
       "note": ""
     },
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "82a17475735c24ddeb83fa1ab4501478ebeede7f7a2313d960571d3ae3b7ad3f",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/redirects_controller.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Redirect.find_by_legacy_path(params[:path]).path, :status => 301, :notice => (\"#{request.env[\"HTTP_HOST\"]}/#{params[:path]} has moved.         Please update bookmarks and links\"))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RedirectsController",
+        "method": "show"
+      },
+      "user_input": "Redirect.find_by_legacy_path(params[:path]).path",
+      "confidence": "High",
+      "note": "Handled in the model before_save hooks"
+    },
+    {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
       "fingerprint": "8d2501ea41801dd441c1ea7b3044ace44aa18f470e19149d4775314d85c2a7e0",
@@ -161,130 +150,6 @@
       },
       "user_input": "params[:controller].split(\"/\").last.classify",
       "confidence": "High",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "9b9107ea408fd3c514c0d1a2256b052d680c4cc270f2958d44befa354e0544f2",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/blogs/index.html.erb",
-      "line": 22,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Read more >\", (Unresolved Model).new.link, :class => \"read-more\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/blogs_controller.rb",
-          "rendered": {
-            "name": "blogs/index",
-            "file": "app/views/blogs/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blogs/index"
-      },
-      "user_input": "(Unresolved Model).new.link",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "a467c709a0e6f1ab748f0108b948f1fd1083fecaf23073f589ce2e195ae55aa6",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/blogs/index.html.erb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.label.truncate(52), (Unresolved Model).new.link)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/blogs_controller.rb",
-          "rendered": {
-            "name": "blogs/index",
-            "file": "app/views/blogs/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blogs/index"
-      },
-      "user_input": "(Unresolved Model).new.link",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "9b9107ea408fd3c514c0d1a2256b052d680c4cc270f2958d44befa354e0544f2",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/blogs/index.html.erb",
-      "line": 22,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Read more >\", (Unresolved Model).new.link, :class => \"read-more\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/blogs_controller.rb",
-          "rendered": {
-            "name": "blogs/index",
-            "file": "app/views/blogs/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blogs/index"
-      },
-      "user_input": "(Unresolved Model).new.link",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "a467c709a0e6f1ab748f0108b948f1fd1083fecaf23073f589ce2e195ae55aa6",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/blogs/index.html.erb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to((Unresolved Model).new.label.truncate(52), (Unresolved Model).new.link)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/blogs_controller.rb",
-          "rendered": {
-            "name": "blogs/index",
-            "file": "app/views/blogs/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blogs/index"
-      },
-      "user_input": "(Unresolved Model).new.link",
-      "confidence": "Weak",
       "note": ""
     },
     {
@@ -333,7 +198,7 @@
           "type": "controller",
           "class": "PersonsController",
           "method": "show",
-          "line": 37,
+          "line": 38,
           "file": "app/controllers/persons_controller.rb",
           "rendered": {
             "name": "persons/show",
@@ -391,6 +256,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-07-17 13:38:59 -0400",
-  "brakeman_version": "4.5.1"
+  "updated": "2019-08-07 12:18:17 -0400",
+  "brakeman_version": "4.6.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,10 @@ en:
         hours: "Hours Identifier"
       space:
         hours: "Hours Identifier"
+      redirect:
+        legacy_path: "Path from Drupal"
+        manifold_path: "Path/URL to Link to"
+        redirectable: "Entity to Link To"
   manifold:
     default:
       event:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     resources :pages
     resources :people
     resources :policies
+    resources :redirects
     resources :services
     resources :spaces
 
@@ -119,6 +120,11 @@ Rails.application.routes.draw do
     get "lcdss" => :tudsc, as: "pages_lcdss"
     get "explore-charles" => :charles, as: "pages_charles"
   end
+
+  controller :redirects do
+    get "*path" => :show
+  end
+
 end
 
 Rails.application.routes.named_routes.url_helpers_module.module_eval do

--- a/db/migrate/20190806225436_create_redirects_table.rb
+++ b/db/migrate/20190806225436_create_redirects_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateRedirectsTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :redirects do |t|
+      t.string :legacy_path
+      t.string :manifold_path
+      t.references :redirectable, polymorphic: true, index: true
+    end
+    add_index :redirects, :legacy_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_190109) do
+ActiveRecord::Schema.define(version: 2019_08_06_225436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -351,6 +351,15 @@ ActiveRecord::Schema.define(version: 2019_07_29_190109) do
     t.datetime "updated_at", null: false
     t.index ["policy_id"], name: "index_policy_applications_on_policy_id"
     t.index ["policyable_type", "policyable_id", "policy_id"], name: "index_uniqueness_policy_application", unique: true
+  end
+
+  create_table "redirects", force: :cascade do |t|
+    t.string "legacy_path"
+    t.string "manifold_path"
+    t.string "redirectable_type"
+    t.bigint "redirectable_id"
+    t.index ["legacy_path"], name: "index_redirects_on_legacy_path"
+    t.index ["redirectable_type", "redirectable_id"], name: "index_redirects_on_redirectable_type_and_redirectable_id"
   end
 
   create_table "service_groups", force: :cascade do |t|

--- a/spec/controllers/redirects_controller_spec.rb
+++ b/spec/controllers/redirects_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RedirectsController, type: :controller do
+
+  describe "GET redirect to a static path" do
+    let(:redirect) { FactoryBot.create(:static_redirect) }
+    it "redirects to the expected path" do
+      get :show, params: { path: redirect.legacy_path }
+      expect(response).to redirect_to(redirect.path)
+    end
+    it "redirects has the 301 status" do
+      get :show, params: { path: redirect.legacy_path }
+      expect(response.status).to eq(301)
+    end
+  end
+
+  describe "GET redirect to another entity" do
+    let(:redirect) { FactoryBot.create(:entity_redirect) }
+    it "redirects to the expected path" do
+      get :show, params: { path: redirect.legacy_path }
+      expect(response).to redirect_to(redirect.path)
+    end
+  end
+
+  describe "GET a non defined redirect" do
+    it "redirects to a 404" do
+      expect { get(:show, params: { path: "not-defined" }) }.
+        to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/factories/redirects.rb
+++ b/spec/factories/redirects.rb
@@ -2,12 +2,18 @@
 
 FactoryBot.define do
   factory :static_redirect, aliases: [:redirect], class: Redirect do
-    legacy_path { "about/hours" }
+    legacy_path { "/about/hours" }
     manifold_path { "/hours" }
   end
 
+  factory :full_url_redirect, class: Redirect do
+    legacy_path { "/srcr/search" }
+    manifold_path { "https://librarysearch.temple.edu/scrc" }
+  end
+
   factory :entity_redirect, class: Redirect do
-    legacy_path { "scrc/research/harmful-language" }
+    legacy_path { "/scrc/research/harmful-language" }
     redirectable { FactoryBot.create(:page) }
   end
+
 end

--- a/spec/factories/redirects.rb
+++ b/spec/factories/redirects.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :static_redirect, aliases: [:redirect], class: Redirect do
+    legacy_path { "about/hours" }
+    manifold_path { "/hours" }
+  end
+
+  factory :entity_redirect, class: Redirect do
+    legacy_path { "scrc/research/harmful-language" }
+    redirectable { FactoryBot.create(:page) }
+  end
+end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Redirect, type: :model do
+
+  describe "#path" do
+    context "a static link" do
+      let(:redirect) { FactoryBot.create(:static_redirect) }
+
+      it "returns the expected path" do
+        expect(redirect.path).to eq "/hours"
+      end
+
+    end
+
+    context "a entity link" do
+      let(:redirect) { FactoryBot.create(:entity_redirect) }
+
+      it "returns the redirectable object" do
+        expect(redirect.path).to eq redirect.redirectable
+      end
+    end
+  end
+
+  describe "#strip_starting_slash_in_legacy_path" do
+    context "the value to be saved starts with a '/'" do
+      it "strips out the starting '/' before saving" do
+        r = Redirect.create!(legacy_path: "/scrc")
+        expect(r.legacy_path).to eq "scrc"
+      end
+    end
+
+    context "the value to be saved contains a '/', but not at the start" do
+      it "does not strip out the middling '/' before saving" do
+        r = Redirect.create!(legacy_path: "pages/scrc")
+        expect(r.legacy_path).to eq "pages/scrc"
+      end
+    end
+  end
+
+  describe "#ensure_starting_slash_in_manifold_path" do
+    context "the value to be saved starts with a '/'" do
+      it "doesn't add an extra '/' before saving" do
+        r = Redirect.create!(manifold_path: "/scrc")
+        expect(r.manifold_path).to eq "/scrc"
+      end
+    end
+
+    context "the value to be saved does not start with a '/'" do
+      it "adds a starting '/' before saving" do
+        r = Redirect.create!(manifold_path: "forms/ask-scrc")
+        expect(r.manifold_path).to eq "/forms/ask-scrc"
+      end
+    end
+  end
+
+end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Redirect, type: :model do
       it "returns the expected path" do
         expect(redirect.path).to eq "/hours"
       end
-
     end
 
     context "a entity link" do
@@ -23,23 +22,23 @@ RSpec.describe Redirect, type: :model do
     end
   end
 
-  describe "#strip_starting_slash_in_legacy_path" do
+  describe "#ensure_starting_slash_in_legacy_path" do
     context "the value to be saved starts with a '/'" do
-      it "strips out the starting '/' before saving" do
+      it "does not strip out the starting '/' before saving" do
         r = Redirect.create!(legacy_path: "/scrc")
-        expect(r.legacy_path).to eq "scrc"
+        expect(r.legacy_path).to eq "/scrc"
       end
     end
 
-    context "the value to be saved contains a '/', but not at the start" do
-      it "does not strip out the middling '/' before saving" do
+    context "the value to be saved does not contain a '/'" do
+      it "adds a strating '/' before saving" do
         r = Redirect.create!(legacy_path: "pages/scrc")
-        expect(r.legacy_path).to eq "pages/scrc"
+        expect(r.legacy_path).to eq "/pages/scrc"
       end
     end
   end
 
-  describe "#ensure_starting_slash_in_manifold_path" do
+  describe "#manifold_path_cleanup" do
     context "the value to be saved starts with a '/'" do
       it "doesn't add an extra '/' before saving" do
         r = Redirect.create!(manifold_path: "/scrc")
@@ -51,6 +50,14 @@ RSpec.describe Redirect, type: :model do
       it "adds a starting '/' before saving" do
         r = Redirect.create!(manifold_path: "forms/ask-scrc")
         expect(r.manifold_path).to eq "/forms/ask-scrc"
+      end
+    end
+
+    context "the value is a URL" do
+      it "returns the original url" do
+        url = "https://librarysearch.temple.edu/srcr"
+        r = Redirect.create!(manifold_path: url)
+        expect(r.manifold_path).to eq url
       end
     end
   end

--- a/spec/requests/admin/redirect_spec.rb
+++ b/spec/requests/admin/redirect_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Redirect, type: :request do
+  it_behaves_like "renderable_dashboard"
+end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -2,16 +2,16 @@
 
 require "rails_helper"
 
-RSpec.describe RedirectsController, type: :controller do
+RSpec.describe RedirectsController, type: :request do
 
   describe "GET redirect to a static path" do
     let(:redirect) { FactoryBot.create(:static_redirect) }
     it "redirects to the expected path" do
-      get :show, params: { path: redirect.legacy_path }
+      get redirect.legacy_path
       expect(response).to redirect_to(redirect.path)
     end
     it "redirects has the 301 status" do
-      get :show, params: { path: redirect.legacy_path }
+      get redirect.legacy_path
       expect(response.status).to eq(301)
     end
   end
@@ -19,14 +19,22 @@ RSpec.describe RedirectsController, type: :controller do
   describe "GET redirect to another entity" do
     let(:redirect) { FactoryBot.create(:entity_redirect) }
     it "redirects to the expected path" do
-      get :show, params: { path: redirect.legacy_path }
+      get redirect.legacy_path
+      expect(response).to redirect_to(redirect.path)
+    end
+  end
+
+  describe "GET redirect to external url" do
+    let(:redirect) { FactoryBot.create(:full_url_redirect) }
+    it "redirects to the expected url" do
+      get redirect.legacy_path
       expect(response).to redirect_to(redirect.path)
     end
   end
 
   describe "GET a non defined redirect" do
     it "redirects to a 404" do
-      expect { get(:show, params: { path: "not-defined" }) }.
+      expect { get("/not-defined") }.
         to raise_error(ActionController::RoutingError)
     end
   end


### PR DESCRIPTION
Adds a redirect model that allows administrate users to

- define an incoming legacy_path ("/scrc/ask")
- define either
  - a static local path it should go to ("/forms/ask-scrc")
  - a redirectable object it should redirect to. Can choose from
    - Buildings
    - Collections
    - Pages
    - Spaces
    - Services
    - Policies

Any non matched redirect reverts to a 404

## Testing

### Static URLS
- Go to the Redirects  admin dashboard  - /admin/redirects
- Create a new redirect
  - add a legacy_url i.e ("scrc/ask-here") (should not start with a slash)
  - add known static path in the manifold_url ("/forms/ask-scrc") (needs to start with a slash)
- go to localhost:3000/scrc/ask-here - it shoudl redirect to localhost:3000/forms/ask-scrc

### Entity redirects
- Create a new redirect
  - add a legacy_url i.e ("some/place") (should not start with a slash)
  - add a redirectable by selecting an entity from the drop down
- go to localhost:3000/some/place - it should redirect to the entity selected in the drop down


