### PR TITLE
#MAN-567 Alignment issue on Blogs page

### DIFF
--- a/app/assets/stylesheets/blogs.scss
+++ b/app/assets/stylesheets/blogs.scss
@@ -80,9 +80,8 @@
 			h2 {
 				color: $black;
 				font-size: 135%;
-				padding: 14px;
+				padding: 14px 14px 14px 0;
 				margin-bottom: 0;
-				padding-bottom: 14px;
 			}
 		}
 		ul {


### PR DESCRIPTION
Please move the left column blog list to the right to align with the title "Library Blogs"
*********************
Aligned title and content in blogs list section.