### PR TITLE
Hours not displaying correct data for dates

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,13 +83,13 @@ class ApplicationController < ActionController::Base
         spaces: [
                   "charles",
                   "service_zone",
-                  "cafe",
                   "scrc",
                   "scholars_studio",
-                  "success_center",
                   "ask_a_librarian",
+                  "24-7",
                   "asrs",
-                  "guest_computers"
+                  "guest_computers",
+                  "cafe"
                 ]
       },
       {

--- a/app/views/application/_building_hours.html.erb
+++ b/app/views/application/_building_hours.html.erb
@@ -44,7 +44,7 @@
       <div class="col-9">
         <div class="row">
 
-        <% @building.get_hours.each_with_index do |time,index| %> <!-- hours -->
+        <% @building.get_hours.sort_by(&:date).each_with_index do |time,index| %> <!-- hours -->
 
           <% if @building.monday.to_date+index == @today.to_date %>
             <div class="col today">

--- a/app/views/application/_building_mobile_hours.html.erb
+++ b/app/views/application/_building_mobile_hours.html.erb
@@ -34,7 +34,7 @@
 
     <div class="col-5 text-left">
 
-      <% @building.get_hours.each_with_index do |time,index| %> <!-- hours -->
+      <% @building.get_hours.sort_by(&:date).each_with_index do |time,index| %> <!-- hours -->
       <% if @monday.to_date+index == @today.to_date %>
           <div class="today day-of-week hours-dates">
           <% else %>

--- a/app/views/application/_space_hours.html.erb
+++ b/app/views/application/_space_hours.html.erb
@@ -44,7 +44,7 @@
       <div class="col-9">
         <div class="row">
 
-        <% @space.get_hours.each_with_index do |time,index| %> <!-- hours -->
+        <% @space.get_hours.sort_by(&:date).each_with_index do |time,index| %> <!-- hours -->
 
           <% if @monday.to_date+index == @today.to_date %>
             <div class="col today">

--- a/app/views/application/_space_mobile_hours.html.erb
+++ b/app/views/application/_space_mobile_hours.html.erb
@@ -34,7 +34,7 @@
 
     <div class="col-5 text-left">
 
-      <% @space.get_hours.each_with_index do |time,index| %> <!-- hours -->
+      <% @space.get_hours.sort_by(&:date).each_with_index do |time,index| %> <!-- hours -->
       <% if @monday.to_date+index == @today.to_date %>
           <div class="today day-of-week hours-dates">
           <% else %>

--- a/app/views/library_hours/_desktop.html.erb
+++ b/app/views/library_hours/_desktop.html.erb
@@ -28,7 +28,7 @@
           <div class="col-3 px-0"> 
             <h3><%= location_link(space[1].first.location_id) %></h3>
           </div>
-          <% space[1].each_with_index do |time,index| %> 
+          <% space[1].sort_by(&:date).each_with_index do |time,index| %> 
             <% if @monday.to_date+index == @today %>
               <div class="col today">
               <% else %>
@@ -36,7 +36,7 @@
             <% end %>
             <% if time.hours.downcase == "closed" %>
               <span class="closed"><%= time.hours %></span>
-              <% else %>
+            <% else %>
               <%= time.hours %>
             <% end %>
             </div>


### PR DESCRIPTION
Dates needed to be sorted within the seven day range displayed in the views. 
The order becomes random if any updates are made in the spreadsheet to a date within the range.