### PR TITLE
#MAN-574 Refactor page views on main menu items

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -9,7 +9,7 @@
 			/*text-decoration: underline;*/
 		}
 	}
-	h2 {
+	h2 a {
 		color: $red;
 	}
 	.chat-box div {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -125,6 +125,8 @@ class PagesController < ApplicationController
 
   def contact
     @fcn_link = Page.find_by_slug("numbers")
+    @libanswers = ExternalLink.find_by_slug("libanswers")
+    @suggestions = Blog.find_by_slug("suggestions").base_url
   end
 
   def show

--- a/app/views/pages/_categories.html.erb
+++ b/app/views/pages/_categories.html.erb
@@ -8,12 +8,16 @@
 		<% unless category.categories.include?(category) %>
 
 			<div class="col-12 col-md-6 col-lg-4 text-center">
+				<h2>
+		    <%= link_to category do %>
 				<% unless category.image.attachment.nil? %>
-					<%= link_to (image_tag category.image, class: "category-icon decorative"), category_path(category) %> 
+					<%= image_tag category.image, class: "category-icon decorative" %> 
 				<% else %>
-					<%= link_to (image_tag "T-borderless.gif", class: "decorative"), category_path(category) %>
+					<%= image_tag "T-borderless.gif", class: "decorative" %>
 				<% end %>
-				<h2><%= link_to category.name, category_path(category) %></h2>
+					<br /><%= category.name %>
+				<% end %>
+				</h2>
 				<p><%= category.description unless category.description.blank? %></p>
 			</div>
 

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -37,19 +37,30 @@
 		</div>
 
 		<div class="col-12 col-md-6 col-lg-4">
-			<%= link_to (image_tag "search-dark.png", class: "category-icon decorative"), "https://answers.library.temple.edu/" %>
-			<h2><%= link_to "Search FAQs", "https://answers.library.temple.edu/" %></h2>
-			<p></p>
+			<%= link_to @libanswers do %>
+			<h2>
+				<%= image_tag "search-dark.png", class: "category-icon decorative"  %>
+				<br />Search FAQs
+			</h2>
+			<% end %>
 		</div>
+
 		<div class="col-12 col-md-6 col-lg-4">
-			<%= link_to (image_tag "collection.png", class: "category-icon decorative"), "/forms/ask-scrc" %>
-			<h2><%= link_to "Special Collections", "/forms/ask-scrc" %></h2>
-			<p></p>
+			<%= link_to "/forms/ask-scrc" do %>
+			<h2>
+				<%= image_tag "collection.png", class: "category-icon decorative"  %>
+				<br />Special Collections
+			</h2>
+			<% end %>
 		</div>
+
 		<div class="col-12 col-md-6 col-lg-4">
-			<%= link_to (image_tag "feedback.png", class: "category-icon decorative"), "http://sites.temple.edu/librarysuggestions" %>
-			<h2><%= link_to "Give Us Your Feedback", "http://sites.temple.edu/librarysuggestions" %></h2>
-			<p></p>
+			<%= link_to strip_tags(@suggestions) do %>
+			<h2>
+				<%= image_tag "feedback.png", class: "category-icon decorative"  %>
+				<br />Give Us Your Feedback
+			</h2>
+			<% end %>
 		</div>
 
 </div>

--- a/app/views/pages/contact/_four.html.erb
+++ b/app/views/pages/contact/_four.html.erb
@@ -1,3 +1,10 @@
-<%= link_to (image_tag "profile.png", class: "category-icon decorative"), people_path %>
-			<h2><%= link_to "Staff Directory", people_path %></h2>
-			<p><%= link_to "Find your subject librarian", people_path(specialists: true) %>, make an appointment, or contact another library staff member.</p>
+<%= link_to people_path do  %>
+	<h2>
+		<%= image_tag "profile.png", class: "category-icon decorative" %>
+		<br />Staff Directory 
+	</h2>
+<% end %>
+
+<p>
+	<%= link_to "Find your subject librarian", people_path(specialists: true) %>, make an appointment, or contact another library staff member.
+</p>

--- a/app/views/pages/contact/_one.html.erb
+++ b/app/views/pages/contact/_one.html.erb
@@ -1,3 +1,3 @@
 <%= image_tag "phone-handle.png", class: "category-icon decorative" %>
-			<h2>Call</h2>
-			<p>215-xxx-xxxx<br />Other <%= link_to "Frequently Called Numbers", @fcn_link %></p>
+<h2>Call</h2>
+<p>215-xxx-xxxx<br />Other <%= link_to "Frequently Called Numbers", @fcn_link %></p>

--- a/app/views/pages/contact/_three.html.erb
+++ b/app/views/pages/contact/_three.html.erb
@@ -1,3 +1,8 @@
-<%= link_to (image_tag "email.png", class: "category-icon decorative"), controller: "pages", action: "show", id: 13 %>
-			<h2><%= link_to "Email", controller: "pages", action: "show", id: 13 %></h2>
-			<p>Email us your question at <%= mail_to "asktulibrary@temple.edu" %></p>
+<%= link_to @form_link do %>
+	<h2>
+		<%= image_tag "email.png", class: "category-icon decorative" %>
+		<br />Email
+	</h2>
+<% end %>
+
+<p>Email us your question at <%= mail_to "asktulibrary@temple.edu" %></p>

--- a/app/views/pages/contact/_two.html.erb
+++ b/app/views/pages/contact/_two.html.erb
@@ -1,3 +1,3 @@
 <%= image_tag "mobile-text.png", class: "category-icon decorative" %>
-			<h2>Text</h2>
-			<p>267-415-8925</p>
+<h2>Text</h2>
+<p>267-415-8925</p>


### PR DESCRIPTION
The pages associated with the main menu items, showing the categories assigned to that parent category, need to be redone to make the icon links and the text links into one link with and icon and text in it. This is for accessibility.
**************************
Remove duplicate links in category views. 
Remove internal links using IDs and change to slugs where possible.

Some instance variables have been set to sue slugs. Slugs needed for this PR are:
-     @fcn_link = Page.find_by_slug("numbers")
-     @libanswers = ExternalLink.find_by_slug("libanswers")
-     @suggestions = Blog.find_by_slug("suggestions").base_url
