### PR TITLE
#MAN-578 Mobile staff directory - make appointment button not displaying properly

### DIFF
--- a/app/assets/stylesheets/persons.scss
+++ b/app/assets/stylesheets/persons.scss
@@ -139,6 +139,13 @@
 				padding:7px 14px;
 				border-radius: 7px;
 			}
+			@media (max-width: 1039px) {
+				a {
+					display: block;
+					margin-bottom: 4px;
+					width: 180px;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Updated appointment button for mobile view: preventing awkward word wrap by displaying buttons as stacking blocks.