### PR TITLE
#MAN-583 Fix address alignment in library page

### DIFF
--- a/app/assets/stylesheets/buildings.scss
+++ b/app/assets/stylesheets/buildings.scss
@@ -5,14 +5,42 @@
 	margin-bottom: 21px;
 
 	.building-contact {
-		line-height: 2rem;
 		li {
 			padding-left: 35px;
-			background-image: asset-data-url('newspaper.png');
+	    background: rgba(255,255,255,0.6);
 	    background-position: 0 center;
 	    background-repeat: no-repeat;
-	    background-size: 28px 28px;
+	    background-size: 42px 42px;
+			line-height: 1.1rem;
+			height: 42px;
+			span {
+				vertical-align: middle;
+				padding-top: 6px;
+				display: inline-block;
+			}
 		}
+		li.lib_location {
+	    background: rgba(255,255,255,0.6);
+	    /*background-position: 0 0;*/
+	    background-repeat: no-repeat;
+	    background-size: 32px 32px;
+			background-image: asset-data-url('small_location.png');
+		}
+		li.lib_phone {
+	    background: rgba(255,255,255,0.6);
+	    /*background-position: 0 0;*/
+	    background-repeat: no-repeat;
+	    background-size: 32px 32px;
+			background-image: asset-data-url('small_phone.png');
+		}
+		li.lib_email {
+	    background: rgba(255,255,255,0.6);
+	    /*background-position: 0 0;*/
+	    background-repeat: no-repeat;
+	    background-size: 32px 32px;
+			background-image: asset-data-url('small_email.png');
+		}
+
 	}
 
 	.building-map {

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -15,9 +15,9 @@
     
       <h1 class="page-title"><%= @building.label %></h1>
       <ul class="list-unstyled building-contact">
-        <li><%= @building.address1 %> <%= @building.address2 %></li>
-        <li><%= phone_formatted(@building.phone_number) %></li>
-        <li><%= mail_to @building.email %></li>
+        <li class="lib_location"><span><%= @building.address1 %> <%= @building.address2 %></span></li>
+        <li class="lib_phone"><span><%= phone_formatted(@building.phone_number) %></span></li>
+        <li class="lib_email"><span><%= mail_to @building.email %></span></li>
       </ul>
       <%= sanitize @building.description.html_safe %>
 

--- a/app/views/spaces/show.html.erb
+++ b/app/views/spaces/show.html.erb
@@ -17,7 +17,7 @@
 
       <div class="details">
         <ul class="list-unstyled space-contact">
-          <li><%= image_tag "small_location.png", class: "location decorative" %><%= link_to @space.building.label, building_path(@space.building), class: "location decorative" %></li>
+          <li><%= image_tag "small_location.png", class: "location decorative" %><%= link_to @space.building.label, building_path(@space.building), class: "location" %></li>
           <li><%= image_tag "small_phone.png", class: "location decorative" %><%= @space.phone_number ? phone_formatted(@space.phone_number) : phone_formatted(@space.building.phone_number) %></li>
           <li><%= image_tag "small_email.png", class: "location decorative" %><%= mail_to @space.building.email unless @space.building.email.nil? %></li>
         </ul>


### PR DESCRIPTION
1. Please fix the spacing on the address. If an address takes up two lines, they should be closer together.
2. Is it possible to make the icon top-align with the text next to it instead of middle-aligned?
3. See: https://web.qa.tul-infra.page/libraries/3
4. replace with the same icons you’re using for the space entity

*********************
Changed icons. Adjusted spacing.