### PR TITLE
Allow urls paths in External Links

### DIFF
--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -5,10 +5,24 @@ class ExternalLink < ApplicationRecord
   include Validators
   include Categorizable
 
-  validates :title, presence: true
-  validates :link, presence: true, url: true
+  before_save :link_cleanup!
+
+  validates :title, :link, presence: true
 
   def label
     title
+  end
+
+  def link_cleanup!
+    if self.link.present?
+      # if it is not a full url
+      unless self.link =~ URI::DEFAULT_PARSER.regexp[:ABS_URI]
+        # and it doesn't already start with /
+        unless self.link.starts_with?("/")
+          # prepend /
+          self.link = self.link.prepend("/")
+        end
+      end
+    end
   end
 end

--- a/spec/factories/external_links.rb
+++ b/spec/factories/external_links.rb
@@ -5,8 +5,9 @@ FactoryBot.define do
     title { "MyString" }
     link { "https://example.org" }
 
-    factory :external_link_bad_url do
-      link { "not://a:url" }
+    factory :external_link_internal_path do
+      title { "Internal Path" }
+      link { "/path/to/thing" }
     end
   end
 end

--- a/spec/models/external_link_spec.rb
+++ b/spec/models/external_link_spec.rb
@@ -14,11 +14,6 @@ RSpec.describe ExternalLink, type: :model do
         end
       end
     end
-    context "checks for a well formed url" do
-      it "raises and error when an invalid url is submitted" do
-        expect { FactoryBot.create(:external_link_bad_url) }.to raise_error(/#{I18n.t('manifold.error.invalid_url')}/)
-      end
-    end
   end
 
   describe "version all fields" do
@@ -33,6 +28,30 @@ RSpec.describe ExternalLink, type: :model do
         external_link.update(k => v.last)
         external_link.save!
         expect(external_link.versions.last.changeset[k]).to match_array(v)
+      end
+    end
+  end
+
+  describe "#link_cleanup!" do
+    context "the value to be saved starts with a '/'" do
+      it "doesn't add an extra '/' before saving" do
+        el = ExternalLink.create!(title: "Explore Charles", link: "/explore-charles")
+        expect(el.link).to eq "/explore-charles"
+      end
+    end
+
+    context "the value to be saved does not start with a '/'" do
+      it "adds a starting '/' before saving" do
+        el = ExternalLink.create!(title: "Explore Charles", link: "explore-charles")
+        expect(el.link).to eq "/explore-charles"
+      end
+    end
+
+    context "the value is a URL" do
+      it "returns the original url" do
+        url = "https://librarysearch.temple.edu/srcr"
+        el = ExternalLink.create!(title: "Explore Charles", link: url)
+        expect(el.link).to eq url
       end
     end
   end


### PR DESCRIPTION
Allow urls paths in the External Links link field, so that we can link to static paths in the manifodl app from nav menu's.