### PR TITLE
Don't make font awesome charaters larger

### DIFF
--- a/app/assets/stylesheets/persons.scss
+++ b/app/assets/stylesheets/persons.scss
@@ -37,14 +37,12 @@
 	a[data-toggle="collapse"]:after {
 		content: "\f105";
     font-family: "FontAwesome";
-    font-size: larger;
   	float: right;
   	padding-right: 7px;
 	}
 	a[aria-expanded="true"]:after {
 		content: "\f107";
     font-family: "FontAwesome";
-    font-size: larger;
   	float: right;
   	padding-right: 7px;
 	}


### PR DESCRIPTION
The downward carrot that indicates a opened facet on events show pages (what else can I call that thing) was way to big in IE, so I've removed the larger font size declaration. Has a minimal effect on other browsers, making it ust a tiny bit smaller.