### PR TITLE
MAN-605 Test that the event is now or in the future

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -56,7 +56,7 @@ class PagesController < ApplicationController
     unless research_links.nil?
       @research_links = research_links.items.sort_by { |e| e.label }
     end
-    @event_links = Event.where("tags LIKE ?", "%Digital Scholarship%").take(5)
+    @event_links = Event.where(["tags LIKE ? and end_time >= ?", "%Digital Scholarship%", Time.now]).take(5)
     @blog = Blog.find_by_slug("lcdss-blog")
     @blog_posts = @blog.blog_posts.take(5)
     @info = Space.find_by_slug("lcdss")
@@ -69,7 +69,7 @@ class PagesController < ApplicationController
     @visit_links = Category.find_by_slug("hsl-study").items.sort_by { |e| e.label }
     @resource_links = Category.find_by_slug("hsl-resources").items.sort_by { |e| e.label }
     @research_links = Category.find_by_slug("hsl-research").items.sort_by { |e| e.label }
-    @event_links = Event.where("tags LIKE ?", "%Health Science%").take(5)
+    @event_links = Event.where(["tags LIKE ? and end_time >= ?", "%Health Science%", Time.now]).take(5)
   end
 
   def about


### PR DESCRIPTION
The links in this box aren't current workshops.  The only way to see current workshops is to click on "view all".

- This collects the events that end after the current time and shows takes the next 5.
- Change applied to HSL and LCDSS events.