### PR TITLE
Add Events & Exhibits explanation

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,8 @@
 
 <div class="container event-index">
 
-  <h1 class="d-none d-lg-block">Events &amp; Exhibits</h1>
+  <h1 class="d-none d-lg-block"><%= t("manifold.events.page_title") %></h1>
+  <p class="d-lg-block"><%= t("manifold.events.explanation").html_safe %></p>
 
   <div class="row">
     <div class="col-3 leftside-index d-none d-md-none d-lg-block">
@@ -23,22 +24,23 @@
     <div class="col-12 col-lg-3 exhibits">
       <% unless @exhibitions.blank? %>
           <div class="col-12 exhibits-header">
-            Current Exhibits
+            <%= t("manifold.events.current_exhibits_label") %>
           </div>
 
         <%= render "exhibitions" %>
       <% end %>
 
         <div class="col-12 px-0">
-          <%= link_to "View past events & exhibits", past_events_path, class: "past-events-button" %>
+          <%= link_to t("manifold.events.view_past_events"), past_events_path, class: "past-events-button" %>
         </div>
 
         <div class="col-12 d-none">
-          <%= link_to "View video recordings from past events", events_path, class: "video-button" %>
+          <%= link_to t("manifold.events.view_past_events_videos"), events_path, class: "video-button" %>
         </div>
 
         <div class="col-12 exhibit">
-          All Temple University Libraries events are free and open to all.
+
+          <%= t("manifold.events.general_admission") %>
         </div>
 
     </div>

--- a/app/views/events/past.html.erb
+++ b/app/views/events/past.html.erb
@@ -2,7 +2,8 @@
 
 <div class="container event-index">
 
-  <h1 class="d-none d-lg-block">Past Events &amp; Exhibits</h1>
+  <h1 class="d-none d-lg-block"><%= t("manifold.events.page_title") %></h1>
+  <p class="d-lg-block"><%= t("manifold.events.explanation").html_safe %></p>
 
   <div class="row">
     <div class="col-3 leftside-index d-none d-md-none d-lg-block">
@@ -11,7 +12,7 @@
     <div class="col-12 col-lg-6 events">
       <div class="row">
         <div class="upcoming-header">
-          Past Events
+          <%= t("manifold.events.past_events_label") %>
         </div>
       </div>
       
@@ -28,22 +29,22 @@
       <% unless @exhibitions.blank? %>
 
       <div class="col-12 exhibits-header">
-        Current Exhibits
+        <%= t("manifold.events.current_exhibits_label") %>
       </div>
 
       <%= render "exhibitions" %>
       <% end %>
 
       <div class="col-12 px-0">
-        <%= link_to "View current events & exhibits", events_path, class: "past-events-button" %>
+        <%= link_to t("manifold.event.view_current_events"), events_path, class: "past-events-button" %>
       </div>
 
       <div class="col-12 d-none">
-        <%= link_to "View video recordings from past events", events_path, class: "video-button" %>
+        <%= link_to t("manifold.event.view_past_events_videos"), events_path, class: "video-button" %>
       </div>
 
       <div class="col-12 exhibit">
-        All Temple University Libraries events are free and open to all.
+        <%= t("manifold.events.general_admission") %>
       </div>
 
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,3 +182,20 @@ en:
       notification:
         all_blogs_synced: "Blogs: All synched"
         blog_synced: "Blogs: %{id} - %{title} synced"
+    events:
+      page_title: "Events & Exhibits"
+      explanation: >
+        Temple University Libraries offer a variety of events and workshops
+        throughout the semester under our <strong>Beyond the Page</strong>
+        series. This series invites scholars, writers, artists, and experts
+        in a variety of fields to address topics pertinent to scholarship
+        at Temple and of importance to the university and the surrounding
+        community. Our workshops and programs take place in all of our
+        Libraries and campuses, including our Health Sciences Libraries and
+        Charles L. Blockson Afro-American Collection.
+      current_exhibits_label: "Current Exhibits"
+      past_events_label: "Past Events"
+      view_current_events: "View current events & exhibits."
+      view_past_events: "View past events & exhibits"
+      view_past_events_videos: "View video recordings from past events"
+      general_admission: "Most Temple University Libraries events are free and open to all."


### PR DESCRIPTION
MAN-610
After a closer review of the events page, we would like to make the
following updates:

1) Please update the text to say "Most Temple University Libraries events
are free and open to all." We want to clarify that not all are open to all
(especially our workshops and events at other library locations)

2) When I spoke with Cynthia about the page, she mentioned it would be
possible to add brief text at the top of the site to explain our events. We
would like to have the text say "Temple University Libraries offer a
variety of events and workshops throughout the semester under our *Beyond
the Page* series. This series invites scholars, writers, artists, and
experts in a variety of fields to address topics pertinent to scholarship
at Temple and of importance to the university and the surrounding
community. Our workshops and programs take place in all of our Libraries
and campuses, including our Health Sciences Libraries and Charles L.
Blockson Afro-American Collection."