### PR TITLE
Refactor to handle scrc/* finding aids AND redirects

### DIFF
--- a/app/controllers/concerns/redirect_logic.rb
+++ b/app/controllers/concerns/redirect_logic.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RedirectLogic
+  extend ActiveSupport::Concern
+
+  def redirect_or_404
+    redirect = Redirect.find_by_legacy_path(legacy_path)
+    if redirect
+      message =
+      "#{request.env['HTTP_HOST']}#{legacy_path} has moved. \
+      Please update bookmarks and links"
+      redirect_to(redirect.path,
+                  status: 301,
+                  notice: message
+                  )
+    else
+      raise ActionController::RoutingError.new("Not Found")
+    end
+  end
+
+  def legacy_path
+    request.env["REQUEST_URI"]
+  end
+end

--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -48,11 +48,6 @@ class FindingAidsController < ApplicationController
 
   private
     def set_finding_aid
-      if params[:id]
-        @finding_aid = FindingAid.find(params[:id])
-      elsif params[:path]
-        @finding_aid = FindingAid.find_by_path(params[:path])
-        redirect_to finding_aid_path(@finding_aid), status: 301
-      end
+      @finding_aid = FindingAid.find(params[:id])
     end
 end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
 class RedirectsController < ApplicationController
+  include RedirectLogic
+
   def show
-    if params[:path]
-      path_with_slash = "/#{params[:path]}"
-      redirect = Redirect.find_by_legacy_path(path_with_slash)
-      if redirect
-        message =
-        "#{request.env['HTTP_HOST']}#{path_with_slash} has moved. \
-        Please update bookmarks and links"
-        redirect_to(redirect.path,
-                    status: 301,
-                    notice: message
-                     )
-      else
-        raise ActionController::RoutingError.new("Not Found")
-      end
-    end
+    redirect_or_404
   end
 end

--- a/app/controllers/scrc_controller.rb
+++ b/app/controllers/scrc_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ScrcController < ApplicationController
+  include RedirectLogic
+
+  def show
+    if matches_finding_aid
+      redirect_to(finding_aid_path(@finding_aid), status: 301)
+    else
+      redirect_or_404
+    end
+  end
+
+  def matches_finding_aid
+    @finding_aid = FindingAid.find_by_path(legacy_path)
+    !!@finding_aid
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -62,26 +62,6 @@
       "note": ""
     },
     {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "75cc43dcda5755d4734e743e6fdfa9647192d58b93962aba7703e2a8f04e47ad",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/redirects_controller.rb",
-      "line": 11,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Redirect.find_by_legacy_path(\"/#{params[:path]}\").path, :status => 301, :notice => (\"#{request.env[\"HTTP_HOST\"]}#{\"/#{params[:path]}\"} has moved.         Please update bookmarks and links\"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "RedirectsController",
-        "method": "show"
-      },
-      "user_input": "Redirect.find_by_legacy_path(\"/#{params[:path]}\").path",
-      "confidence": "High",
-      "note": "External URLS are a valid redirect here"
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "7a8e4552d89bb53cf073729b06e4f1f6489e74f3657f7bc5f521e847f1e28b88",
@@ -129,6 +109,26 @@
         "template": "alerts/show"
       },
       "user_input": null,
+      "confidence": "High",
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "895f86f0109eef7b6ffa3522bbaf52322ee749274d57e56dd9b2a4f20f22e776",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/concerns/redirect_logic.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Redirect.find_by_legacy_path(legacy_path).path, :status => 301, :notice => (\"#{request.env[\"HTTP_HOST\"]}#{legacy_path} has moved.       Please update bookmarks and links\"))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RedirectLogic",
+        "method": "redirect_or_404"
+      },
+      "user_input": "Redirect.find_by_legacy_path(legacy_path).path",
       "confidence": "High",
       "note": ""
     },
@@ -256,6 +256,6 @@
       "note": ""
     }
   ],
-  "updated": "2019-08-07 14:30:00 -0400",
+  "updated": "2019-08-22 16:19:41 -0400",
   "brakeman_version": "4.6.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,10 +83,6 @@ Rails.application.routes.draw do
   resources :library_hours, only: [:index, :show], as: :hours, path: "/hours"
   resources :forms, only: [:new, :create]
   resources :finding_aids, only: [:index, :show]
-  controller :finding_aids do
-    get "scrc/:path" => :show
-  end
-
   resources :pages, only: [:index, :show]
   resources :highlights, only: [:index, :show]
   resources :categories, only: [:show]
@@ -105,6 +101,10 @@ Rails.application.routes.draw do
 
   controller :blogs do
     get "news" => :index, as: "news"
+  end
+
+  controller :scrc do
+    get "scrc/*path" => :show
   end
 
   controller :pages do

--- a/spec/controllers/scrc_controller_spec.rb
+++ b/spec/controllers/scrc_controller_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScrcController, type: :controller do
+
+end

--- a/spec/factories/finding_aids.rb
+++ b/spec/factories/finding_aids.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     content_link { "MyString" }
     identifier { "MyString" }
     drupal_id { "MyString" }
+    path { "a-finding-aid" }
   end
 end

--- a/spec/requests/scrc_controller.rb
+++ b/spec/requests/scrc_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScrcController, type: :request do
+
+  describe "request for a path that is a finding aid" do
+    let(:finding_aid) { FactoryBot.create(:finding_aid) }
+    it "redirects to the finding aid controller" do
+      get "/scrc/a-finding-aid"
+      expect(response).to redirect_to(finding_aid_path(finding_aid))
+    end
+  end
+
+  describe "request for a path that is a redirect" do
+    it "redirects to the the expected redirect" do
+      let(:redirect) { FactoryBot.create(:entity_redirect) }
+      get redirect.legacy_path
+      expect(response).to redirect_to(redirect.path)
+    end
+  end
+
+  describe "request for a path that a finding aid or redirect" do
+    it "404s" do
+      get "/scrc/nopesauce"
+      expect(response).to redirect_to("errors#not_found")
+    end
+  end
+end

--- a/spec/routing/finding_aids_routing_spec.rb
+++ b/spec/routing/finding_aids_routing_spec.rb
@@ -3,11 +3,19 @@
 require "rails_helper"
 
 RSpec.describe FindingAidsController, type: :routing do
-  describe "routing" do
-
+  describe "standard routing" do
     it "routes to #show" do
       expect(get: "/finding_aids/1").to route_to("finding_aids#show", id: "1")
     end
-
   end
+  describe "redirect routing" do
+    before { FactoryBot.create(:finding_aid) }
+    context "legacy scrc search path" do
+      it "does not get routed to the finding aid controller" do
+        expect(get: "/scrc/search")
+          .not_to route_to("finding_aids#show", path: "search")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Turns out there are lots of legacy paths at `/scrc/*`, not just finding aids. This adds support for redirects as well as finding aids for requests coming it at the `/scrc/*` path. Anything not matching either will 404.

Please test:

A known finding aid with a legacy path (localhost:3000/scrc/abraham-l-freedman-papers-2 -> localhost:3000/finding_aids/46

(for local testing you may need to add the redirects)
A known non scrc redirect ( /asktulibraries  ->      /contact-us )
A known scrc redirect (     /scrc/research/harmful-language -> /policies/14