### PR TITLE
#MAN-603 Update EZborrow link in Footer

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -37,7 +37,7 @@
             <div class="col-12 col-lg-4 px-0">
               <ul class="list-unstyled">
                 <% unless @ezborrow_link.nil? %>
-                <li><%= link_to "EZ-borrow", @ezborrow_link.link %></li>
+                <li><%= link_to "E-Zborrow", @ezborrow_link.link %></li>
                 <% end %>
                 <% unless @jobs_link.nil? %>
                 <li><%= link_to "Jobs", page_path(@jobs_link) %></li>


### PR DESCRIPTION
The current EZborrow link is written as follows: EZ-borrow

However, PALCI has EZborrow written as E-ZBorrow