### PR TITLE
#MAN-609 Website: no link to main Temple University website?

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -47,7 +47,7 @@
                 <% end %>
               </ul>
             </div>
-            <div class="col-12 col-lg-4 px-0">
+            <div class="col-12 col-lg-3 px-0">
               <ul class="list-unstyled">
                 <% unless @illiad_link.nil? %>
                 <li><%= link_to "ILLiad", @illiad_link.link %></li>
@@ -60,7 +60,7 @@
                 <% end %>
               </ul>
             </div>
-            <div class="col-12 col-lg-4 px-0">
+            <div class="col-12 col-lg-5 px-0">
               <ul class="list-unstyled">
                 <% unless @refworks_link.nil? %>
                 <li><%= link_to "RefWorks", @refworks_link.link %></li>
@@ -68,6 +68,7 @@
                 <% unless @privacy_link.nil? %>
                 <li><%= link_to "Virtual Reference Privacy Guidelines", @privacy_link %></li>
                 <% end %>
+                <li><%= link_to "Temple University homepage", "http://temple.edu" %></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
There doesn't seem to be a link back to the main Temple U website from our Library website homepage.  IIRC the Temple T in the upper left used to function to link back to the main Temple website?  Not having a link out to Temple main kind of strands users on our website.