### PR TITLE
Fix finding aid path redirects.

### DIFF
--- a/app/controllers/scrc_controller.rb
+++ b/app/controllers/scrc_controller.rb
@@ -11,8 +11,14 @@ class ScrcController < ApplicationController
     end
   end
 
+
   def matches_finding_aid
-    @finding_aid = FindingAid.find_by_path(legacy_path)
+    @finding_aid = FindingAid.find_by_path(finding_aid_legacy_path)
     !!@finding_aid
+  end
+
+  def finding_aid_legacy_path
+    # Finding aid entities path do not have the starting "/scrc/"
+    legacy_path.gsub(/^\/scrc\//, "")
   end
 end

--- a/spec/requests/scrc_controller_spec.rb
+++ b/spec/requests/scrc_controller_spec.rb
@@ -7,23 +7,22 @@ RSpec.describe ScrcController, type: :request do
   describe "request for a path that is a finding aid" do
     let(:finding_aid) { FactoryBot.create(:finding_aid) }
     it "redirects to the finding aid controller" do
-      get "/scrc/a-finding-aid"
+      get "/scrc/#{finding_aid.path}"
       expect(response).to redirect_to(finding_aid_path(finding_aid))
     end
   end
 
   describe "request for a path that is a redirect" do
+    let(:redirect) { FactoryBot.create(:entity_redirect) }
     it "redirects to the the expected redirect" do
-      let(:redirect) { FactoryBot.create(:entity_redirect) }
       get redirect.legacy_path
       expect(response).to redirect_to(redirect.path)
     end
   end
 
   describe "request for a path that a finding aid or redirect" do
-    it "404s" do
-      get "/scrc/nopesauce"
-      expect(response).to redirect_to("errors#not_found")
+    it "throws and Not Found error" do
+      expect { get "/scrc/nopesauce" }.to raise_error(ActionController::RoutingError)
     end
   end
 end


### PR DESCRIPTION
Finding aid requests of the /scrc/finding-aid-name were no longer working due to changes in the way redirect paths were being handled.

This handles there case.

Also, actually test the scrc controllers now. :(