### PR TITLE
Tell skylight not to track  middleware

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,6 @@ Rails.application.configure do
 
 
   GA.tracker = "UA-2152985-1"
+
+  config.skylight.probes -= ["middleware"]
 end


### PR DESCRIPTION
Skylight was not getting data because of an error in RSwag api
middleware. This reduces the granularity of skylight reporting for
midleware in order to get data on app performance.

https://www.skylight.io/support/troubleshooting#event-errors