### PR TITLE
#MAN-635 Remove 24/7 space from hours

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -86,7 +86,6 @@ class ApplicationController < ActionController::Base
                   "scrc",
                   "scholars_studio",
                   "ask_a_librarian",
-                  "24-7",
                   "asrs",
                   "guest_computers",
                   "cafe"

--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -46,7 +46,6 @@ class LibraryHoursController < ApplicationController
                   "scrc",
                   "scholars_studio",
                   "ask_a_librarian",
-                  "24-7",
                   "asrs",
                   "guest_computers",
                   "cafe"

--- a/app/services/sync_service/library_hours.rb
+++ b/app/services/sync_service/library_hours.rb
@@ -25,8 +25,7 @@ class SyncService::LibraryHours
                   { coordinates: "Sheet2!L2:L", slug: "ambler" },
                   { coordinates: "Sheet2!M2:M", slug: "ginsburg" },
                   { coordinates: "Sheet2!N2:N", slug: "podiatry" },
-                  { coordinates: "Sheet2!O2:O", slug: "innovation" },
-                  { coordinates: "Sheet2!P2:P", slug: "24-7" }
+                  { coordinates: "Sheet2!O2:O", slug: "innovation" }
                 ]
 
     locations.each do |location|

--- a/app/views/library_hours/_desktop.html.erb
+++ b/app/views/library_hours/_desktop.html.erb
@@ -1,5 +1,6 @@
 <% @buildings.each do |location| %>
 
+<% unless location[:slug] == "charles" %>
   <div class="row building-row">
     <div class="col px-0">
       <h2 style="color: #A50030">
@@ -7,6 +8,19 @@
       </h2>
     </div>
   </div>
+<% else %>
+  <div class="row building-row">
+    <div class="col-3 px-0">
+      <h2 style="color: #A50030">
+        <%= location_name(location[:slug]) %>
+      </h2>
+    </div>
+    <div class="col-9">
+      <%= t("manifold.hours.charles_note").html_safe %>
+    </div>
+  </div>
+<% end %>
+
 
   <div class="row"> <!-- dates header -->
     <div class="col-3"></div>

--- a/app/views/library_hours/_mobile.html.erb
+++ b/app/views/library_hours/_mobile.html.erb
@@ -1,5 +1,6 @@
 <% @buildings.each do |location| %>
 
+<% unless location[:slug] == "charles" %>
   <div class="row building-row">
     <div class="col-12">
       <h2 style="color: #A50030">
@@ -7,6 +8,19 @@
       </h2>
     </div>
   </div>
+<% else %>
+  <div class="row building-row">
+    <div class="col-12">
+      <h2 style="color: #A50030">
+        <%= location_name(location[:slug]) %>
+      </h2>
+    </div>
+  </div>
+    <div class="col-12">
+      <%= t("manifold.hours.charles_note").html_safe %>
+    </div>
+<% end %>
+
 
 
   <% unless location[:spaces].first.second.empty? %> <!-- hours for at least one space -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,11 @@ en:
         blog_synced: "Blogs: %{id} - %{title} synced"
     footer:
       patron_forms_label: "Patron Forms"
+    hours:
+      charles_note: >
+        <p><em>While we list opening and closing times for Charles Library below, 
+        the 24/7 space is always available to those affiliated with Temple University. 
+        Use your OwlCard to swipe in at the Liacouras and Polett Walks entrance.</em></p>
     events:
       page_title: "Events & Exhibits"
       explanation: >


### PR DESCRIPTION
But as a start, removing 24/7 as a location and adding a scope note about it at the top of the hours page is a good start.

It could read:

While we list opening and closing times for Charles Library below, the 24/7 space is always available to those affiliated with Temple University. Use your OwlCard to swipe in at the Liacoura and Polett Walks entrance.