### PR TITLE
#MAN-624 Create new Support the Libraries button for footer

### DIFF
--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -50,10 +50,14 @@
 
 a.donate {
 	vertical-align: middle;
-	padding: 7px 0;
+	padding: 7px;
 	position: relative;
 	top: 14px;
 	left: 0;
+	background-color: $white;
+	color: $red!important;
+	font-family: "Roboto Condensed";
+	border-radius: 7px;
 }
 .social {
 	border-bottom: solid $white 1px;

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -3,7 +3,7 @@
   <div class="row social">
     <div class="col-12 col-lg-7 px-0">
       <% unless @donate_link.nil? %>
-        <%= link_to image_tag("give_button.png", alt: "Support the Libraries"), @donate_link, class: "donate", title: "Giving and Gifts in Kind page" %>
+        <%= link_to "Support the Libraries", @donate_link, class: "donate" %>
       <% end %>
     </div>
     <div class="col-12 col-lg-5 text-left text-lg-right px-0 social-link">


### PR DESCRIPTION
Chris, IA told us to remove the gift icon from the button, therefore it doesn't need to be an image file anymore.

Can you make a button- same size and rounded corners as the call to action buttons on the services pages?

-Button with rounded corners
-white fill, no outline
-"Support the Libraries" in cherry red, Roboto Condensed font, 24px
-same location in footer