### PR TITLE
#MAN-637 FWD: correction on calendar

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,9 +45,9 @@ class Event < ApplicationRecord
   def set_times
     unless all_day
       unless end_time.nil? || end_time == start_time
-        start_time.strftime("%l:00 %P") + " - " + end_time.strftime("%l:00 %P")
+        start_time.strftime("%l:%M %P") + " - " + end_time.strftime("%l:%M %P")
       else
-        start_time.strftime("%l:00 %P")
+        start_time.strftime("%l:%M %P")
       end
     else
       "(All day)"


### PR DESCRIPTION
..."here are incorrect times listed for our Thursday Thirty workshops (held
> today, 10/3, 11/7, and 12/5). The start time is 12:15 but the event page
> has 12 pm as the start time. Can this be corrected? It only looks like it's
> an issue on the TUL events pages, like the one seen here:
>
> https://library.temple.edu/events/642
>
> The university events calendar has the correct time."