### PR TITLE
#MAN-622 Events change display name for Sullivan Hall

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -34,4 +34,7 @@ module EventHelper
     event_rdf = JSON.parse event_hash.to_json
     raw(event_rdf.to_json)
   end
+  def get_bldg_name(bldg_name)
+    t("manifold.default.event.#{bldg_name.parameterize.underscore}", default: bldg_name)
+  end
 end

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -12,9 +12,9 @@
       <p><strong>
         <%= event.get_date %> | <%= event.set_times %> 
         <% unless event.building.nil? %>
-          | <%= event.building.name %>
+          | <%= get_bldg_name(event.building.name) %>
         <% else %>
-          | <%= event.external_building %>
+          | <%= get_bldg_name(event.external_building) %>
         <% end %>
       </strong></p>
       <p><%= sanitize strip_tags(event.description.html_safe.truncate(250)) %></p>
@@ -30,10 +30,10 @@
         <% end %>
 
         <% unless event.building.nil? %>
-          <%= link_to event.building.name, event.building, class: "event_location" %>
+          <%= link_to get_bldg_name(event.building.name), event.building, class: "event_location" %>
         <% else %>
           <% unless event.external_building.nil? %>
-            <span class="event_location"><%= event.external_building %></span> 
+            <span class="event_location"><%= get_bldg_name(event.external_building) %></span> 
           <% end %>
         <% end %>
       </p>

--- a/app/views/events/_facets.html.erb
+++ b/app/views/events/_facets.html.erb
@@ -44,7 +44,7 @@
       <% @event_locations.each do |location| %>
         <% unless action_name == "past" %>
           <li<% if location == params[:location] %><% active = true %> class="active"<% end %>>
-            <%= link_to location, events_path(request.query_parameters.merge({location: location, page: 1})) %>
+            <%= link_to get_bldg_name(location), events_path(request.query_parameters.merge({location: location, page: 1})) %>
             <% if active == true %>
             <span class="clear-filter">
               <%= link_to "X", events_path(request.query_parameters.except(:location).merge({page: 1})) %>
@@ -53,7 +53,7 @@
           <% active = false %>
         <% else %>
           <li<% if location == params[:location] %><% active = true %> class="active"<% end %>>
-            <%= link_to location, past_events_path(request.query_parameters.merge({location: location, page: 1})) %>
+            <%= link_to get_bldg_name(location), past_events_path(request.query_parameters.merge({location: location, page: 1})) %>
             <% if active == true %>
             <span class="clear-filter">
               <%= link_to "X", past_events_path(request.query_parameters.except(:location).merge({page: 1})) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
   manifold:
     default:
       event:
+        sullivan_hall: "Sullivan Hall - Blockson Collection"
         title: "No Title"
         description: "No Description"
         external_building: "No Building Given"

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -52,4 +52,17 @@ RSpec.describe EventHelper, type: :helper do
       end
     end
   end
+
+  describe "Get Building Name" do
+    context "receives string with translation" do
+      it "renders the translation" do
+        expect(helper.get_bldg_name("Sullivan Hall")).to include("Sullivan Hall - Blockson Collection")
+      end
+    end
+    context "receives string without translation" do
+      it "renders the default" do
+        expect(helper.get_bldg_name("Kahn Hall")).to eq("Kahn Hall")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Any events that come in from the university event calendar with a location of "Sullivan hall" should be changed to read "Sullivan Hall - Blockson Collection". This is a change to the label that is displayed in Manifold since we cannot change the location that comes through from the university events calendar.