### PR TITLE
#MAN-347 Fix timestamp on hours sync

### DIFF
--- a/app/controllers/admin/library_hours_controller.rb
+++ b/app/controllers/admin/library_hours_controller.rb
@@ -21,7 +21,7 @@ module Admin
     def index
       # get the most recently updated record to find out when
       # the last sync happened
-      @last_sync = LibraryHour.order(:updated_at).take
+      @last_sync = LibraryHour.order(:updated_at).reverse_order.take
       super
     end
   end


### PR DESCRIPTION
Last Library Hours Sync: 09/18/2018 3:38 PM

This is not updating when syncing the hours. It's stuck on the date above.