### PR TITLE
#MAN-166 List of Videos

### DIFF
--- a/app/assets/stylesheets/videos.scss
+++ b/app/assets/stylesheets/videos.scss
@@ -1,0 +1,48 @@
+@import "partials/_vars.scss";
+
+#videos-index {
+	h2 {
+		margin-top: 4px;
+		font-size: 1.75rem;
+		display: inline-block;
+	}
+	.morevideos {
+		float: right;
+		padding-right: 10px;
+		display:inline-block;
+		font-weight: 900;
+		font-family: 'Roboto Condensed';
+		font-size: large;
+	}
+	.even {
+		background-color: rgba(0,0,0,0.08);
+		border-top: solid #ccc 2px;
+		border-bottom: solid #ccc 2px;
+		padding-top: 14px;
+		padding-bottom: 14px;
+	}
+	.odd {
+		padding-top: 14px;
+		padding-bottom: 14px;
+	}
+	#videosearchbutton {
+		color: white;
+    font-size: 115%;
+    background-color: #951936;
+    border: double #f1efe7 4px;
+    border-radius: 4px;
+    padding: 6px 14px;
+    cursor: hand;
+    cursor: pointer;
+    display: inline-block;
+	}
+	#videosearchterm {
+		height: 45px;
+		border: inset #ccc 2px;
+		border-radius: 4px;
+	}
+	#videosearchbar {
+		padding-bottom: 21px;
+		border-bottom: solid #ccc 1px;
+	}
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,9 +4,95 @@ class PagesController < ApplicationController
   before_action :set_date, :todays_date, :get_highlights, only: [:home, :hsl, :ambler]
   before_action :set_page, only: [:show, :charles]
   before_action :navigation_items, only: [:show, :charles]
+  before_action :video_init, only: [:videos_all, :videos_show, :videos_list, :videos_search]
+
+  include HTTParty
 
   def get_highlights
     @highlights = Highlight.where(promoted: true).take(4)
+  end
+
+  def video_init
+    @pageSize = 9
+    @prevPage = 0
+    @nextPage = 2
+    page = params[:page]
+    if page.nil? 
+      @page = "1"
+    else 
+      @prevPage = (@page-1).to_s
+      @nextPage = (@page+1).to_s
+    end
+    @libraryID = 'fd034a20-5fb2-4c61-8269-df7e357e78e1'
+    @basepath = 'https://svc.librarydrupal:123$dc&3K_Fg-s@ensemble.temple.edu/api'
+    @medialibrary = '/medialibrary/'+@libraryID+'?PageIndex='+@page+'&PageSize=1000'
+    @categories = ['All Past Programs','Beyond the Page', 'Beyond the Notes','Charles L. Blockson Collection', 'Livingstone Undergraduate Research Awards', 'Loretta C. Duckworth Scholars Studio', 'Special Collections Research Center']
+    @category = @categories[params[:collection].to_i]
+    @all = []
+    @beyond_page = []
+    @beyond_notes = []
+    @blockson = []
+    @awards = []
+    @lcdss = []
+    @scrc = []
+  end
+
+  def videos_all
+    @displayMode = "all"
+    api_query = @basepath+"/medialibrary/"+@libraryID+"?PageIndex=1&PageSize=1000"
+    @videos = ensemble_api(api_query)
+    @featured_video_id = @videos[:Data].first[:ID]
+    @featured_video_title = @videos[:Data].first[:Title]
+    @videos[:Data].each do |video|
+      tags = video[:Keywords].split(',').each do |tag|
+        case tag
+          when "Beyond the Page"
+            @beyond_page << video
+          when "Beyond the Notes" 
+            @beyond_notes << video
+          when "Charles L. Blockson Collection"
+            @blockson << video
+          when "Livingstone Undergraduate Research Awards"
+            @awards << video
+          when "Loretta C. Duckworth Scholars Studio"
+            @lcdss << video
+          when "Special Collections Research Center"
+            @scrc << video
+        end
+      end
+    end
+  end
+
+  def videos_show
+    @displayMode = "show"
+    api_query = @basepath+"/content/"+params[:id]
+    @videos = ensemble_api(api_query)
+    @featured_video_id = @videos[:ID]
+    @featured_video_title = @videos[:Title]
+    @featured_video_description = @videos[:Description]
+  end
+
+  def videos_list
+    @category = params[:collection]
+    unless @category.nil? || @category.blank? || @category == "0"
+      @categoryTitle = @categories[params[:collection].to_i]
+      api_query = @basepath+@medialibrary+"&FilterValue="+URI::encode(@categoryTitle)
+    else 
+      @categoryTitle = "All Past Programs"
+      api_query = @basepath+@medialibrary
+    end
+      @videos = ensemble_api(api_query)
+  end
+
+  def videos_search
+    api_query = @basepath+@medialibrary+"&FilterValue="+URI::encode(params[:q])
+    @videos = ensemble_api(api_query)
+    @categoryTitle = 'you searched for: "'+params[:q] +'"'
+  end
+
+  def ensemble_api(api_query)
+    videos = HTTParty.get(api_query)
+    JSON.parse(videos&.body, symbolize_names: true)
   end
 
   def charles

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -17,16 +17,16 @@ class PagesController < ApplicationController
     @prevPage = 0
     @nextPage = 2
     page = params[:page]
-    if page.nil? 
+    if page.nil?
       @page = "1"
-    else 
-      @prevPage = (@page-1).to_s
-      @nextPage = (@page+1).to_s
+    else
+      @prevPage = (@page - 1).to_s
+      @nextPage = (@page + 1).to_s
     end
-    @libraryID = 'fd034a20-5fb2-4c61-8269-df7e357e78e1'
-    @basepath = 'https://svc.librarydrupal:123$dc&3K_Fg-s@ensemble.temple.edu/api'
-    @medialibrary = '/medialibrary/'+@libraryID+'?PageIndex='+@page+'&PageSize=1000'
-    @categories = ['All Past Programs','Beyond the Page', 'Beyond the Notes','Charles L. Blockson Collection', 'Livingstone Undergraduate Research Awards', 'Loretta C. Duckworth Scholars Studio', 'Special Collections Research Center']
+    @libraryID = "fd034a20-5fb2-4c61-8269-df7e357e78e1"
+    @basepath = "https://svc.librarydrupal:123$dc&3K_Fg-s@ensemble.temple.edu/api"
+    @medialibrary = "/medialibrary/" + @libraryID + "?PageIndex=" + @page + "&PageSize=1000"
+    @categories = ["All Past Programs", "Beyond the Page", "Beyond the Notes", "Charles L. Blockson Collection", "Livingstone Undergraduate Research Awards", "Loretta C. Duckworth Scholars Studio", "Special Collections Research Center"]
     @category = @categories[params[:collection].to_i]
     @all = []
     @beyond_page = []
@@ -39,25 +39,25 @@ class PagesController < ApplicationController
 
   def videos_all
     @displayMode = "all"
-    api_query = @basepath+"/medialibrary/"+@libraryID+"?PageIndex=1&PageSize=1000"
+    api_query = @basepath + "/medialibrary/" + @libraryID + "?PageIndex=1&PageSize=1000"
     @videos = ensemble_api(api_query)
     @featured_video_id = @videos[:Data].first[:ID]
     @featured_video_title = @videos[:Data].first[:Title]
     @videos[:Data].each do |video|
-      tags = video[:Keywords].split(',').each do |tag|
+      tags = video[:Keywords].split(",").each do |tag|
         case tag
-          when "Beyond the Page"
-            @beyond_page << video
-          when "Beyond the Notes" 
-            @beyond_notes << video
-          when "Charles L. Blockson Collection"
-            @blockson << video
-          when "Livingstone Undergraduate Research Awards"
-            @awards << video
-          when "Loretta C. Duckworth Scholars Studio"
-            @lcdss << video
-          when "Special Collections Research Center"
-            @scrc << video
+        when "Beyond the Page"
+          @beyond_page << video
+        when "Beyond the Notes"
+          @beyond_notes << video
+        when "Charles L. Blockson Collection"
+          @blockson << video
+        when "Livingstone Undergraduate Research Awards"
+          @awards << video
+        when "Loretta C. Duckworth Scholars Studio"
+          @lcdss << video
+        when "Special Collections Research Center"
+          @scrc << video
         end
       end
     end
@@ -65,7 +65,7 @@ class PagesController < ApplicationController
 
   def videos_show
     @displayMode = "show"
-    api_query = @basepath+"/content/"+params[:id]
+    api_query = @basepath + "/content/" + params[:id]
     @videos = ensemble_api(api_query)
     @featured_video_id = @videos[:ID]
     @featured_video_title = @videos[:Title]
@@ -76,18 +76,18 @@ class PagesController < ApplicationController
     @category = params[:collection]
     unless @category.nil? || @category.blank? || @category == "0"
       @categoryTitle = @categories[params[:collection].to_i]
-      api_query = @basepath+@medialibrary+"&FilterValue="+URI::encode(@categoryTitle)
-    else 
+      api_query = @basepath + @medialibrary + "&FilterValue=" + URI::encode(@categoryTitle)
+    else
       @categoryTitle = "All Past Programs"
-      api_query = @basepath+@medialibrary
+      api_query = @basepath + @medialibrary
     end
-      @videos = ensemble_api(api_query)
+    @videos = ensemble_api(api_query)
   end
 
   def videos_search
-    api_query = @basepath+@medialibrary+"&FilterValue="+URI::encode(params[:q])
+    api_query = @basepath + @medialibrary + "&FilterValue=" + URI::encode(params[:q])
     @videos = ensemble_api(api_query)
-    @categoryTitle = 'you searched for: "'+params[:q] +'"'
+    @categoryTitle = 'you searched for: "' + params[:q] + '"'
   end
 
   def ensemble_api(api_query)

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -33,4 +33,12 @@ module PagesHelper
       end
     end
   end
+
+  def title_trim(title) 
+    title.truncate(105)
+  end
+
+  def trim_value(value) 
+    value.strip
+  end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -34,11 +34,11 @@ module PagesHelper
     end
   end
 
-  def title_trim(title) 
+  def title_trim(title)
     title.truncate(105)
   end
 
-  def trim_value(value) 
+  def trim_value(value)
     value.strip
   end
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -34,8 +34,8 @@
           <%= link_to t("manifold.events.view_past_events"), past_events_path, class: "past-events-button" %>
         </div>
 
-        <div class="col-12 d-none">
-          <%= link_to t("manifold.events.view_past_events_videos"), events_path, class: "video-button" %>
+        <div class="col-12 px-0">
+          <%= link_to t("manifold.events.view_past_events_videos"), pages_videos_all_path, class: "video-button" %>
         </div>
 
         <div class="col-12 exhibit">

--- a/app/views/pages/_videos.html.erb
+++ b/app/views/pages/_videos.html.erb
@@ -1,0 +1,34 @@
+<div class="container" style="margin-top: 35px;">
+
+	<div class="row">
+		<div class="col">
+			<h1 class="page-title">Past Program and Event Videos</h1>
+			<% if @displayMode == 'all' %>
+				<div id="featuredTitle"><p><span><%= @featured_video_title %></span></p></div>
+		    <div id="ensembleEmbeddedContent_<%= @featured_video_id %>" class="ensembleEmbeddedContent" style="height: 680px;overflow:hidden;">
+	        <script type="text/javascript" style="position: relative;" src="https://ensemble.temple.edu/app/plugin/plugin.aspx?embed=true&contentID=<%= @featured_video_id %>&isResponsive=false&isNewPluginEmbed=true&useIFrame=false&displayTitle=false&startTime=0&autoPlay=false&hideControls=true&showCaptions=false&displaySharing=true&displayAnnotations=false&displayAttachments=false&displayLinks=false&displayEmbedCode=true&displayDownloadIcon=false&displayMetaData=false&displayDateProduced=false&audioPreviewImage=false&displayCaptionSearch=false"></script>
+		    </div>
+	    <% end %>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col">
+			<hr >
+			<ul>
+			<% @videos[:Data].each do |video| %>
+			<li>
+				<%= image_tag(video[:ThumbnailUrl].sub! "Width=100", "Width=220") %>
+				<br>
+				<%= video[:Title] %></li>
+			<% end %>
+			</ul>
+		</div>
+	</div>
+</div>
+
+<style>
+	.ev-navbar.mb-0.navbar-custom {
+		display: none;
+	}
+</style>

--- a/app/views/pages/videos_all.html.erb
+++ b/app/views/pages/videos_all.html.erb
@@ -1,0 +1,156 @@
+<div class="container" id="videos-index" style="margin-top: 35px;">
+
+<div class="row">
+	<div class="col">
+			<h1 class="page-title">Past Program and Event Videos</h1>
+	<div class="row">
+		<div class="col-10 offset-lg-1" style="height:620px;">
+				<div id="featuredTitle" class="text-center"><p><%= @featured_video_title %></p></div>
+		    <iframe id="ensembleEmbeddedContent_<%= @featured_video_id %>" src="https://ensemble.temple.edu/app/plugin/embed.aspx?ID=<%= @featured_video_id %>&amp;contentID=<%= @featured_video_id %>&amp;autoplay=false&amp;hideControls=false&amp;showCaptions=true&amp;width=584&amp;embed=true&amp;startTime=0&amp;displayCaptionSearch=false&amp;isResponsive=true&amp;isNewPluginEmbed=true&amp;displayDownloadIcon=false&amp;displaySharing=false&amp;displayMetaData=false&amp;displayAnnotations=true&amp;displayDateProduced=&amp;displayEmbedCode=false&amp;displayStatistics=false&amp;displayAttachments=true&amp;displayLinks=false&amp;displayCredits=false&amp;displayViewersReport=false&amp;displayTitle=false&amp;audioPreviewImage=true&amp;useIFrame=true" frameborder="0" style="width: 100%; height: 100%;" scrolling="no" allowfullscreen=""></iframe>
+		</div>
+	</div>
+</div>
+</div>
+
+<div class="row">
+	<div class="col text-center">
+		<div id="videosearchbar">
+    <form action="/watchpastprograms/search" method="GET">
+        <label style="display:none;" for="videosearchterm">Search all Past Program videos:</label>
+        <input type="text" id="videosearchterm" name="q" size="64" maxlength="128" value="">
+        <input type="submit" id="videosearchbutton" value="Search">
+    </form>
+		</div>
+	</div>
+</div>
+
+	<div class="row odd">
+		<div class="col">
+			<h2>Beyond the Page</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/0">See All Beyond the Page Videos</a>
+			</span>
+			<div class="row">
+				<% @beyond_page.take(8).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+
+	<div class="row even">
+		<div class="col">
+			<h2>Beyond the Notes</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/1">See All Beyond the Notes Videos</a>
+			</span>
+			<div class="row">
+				<% @beyond_notes.take(4).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+
+	<div class="row odd">
+		<div class="col">
+			<h2>Charles L. Blockson Afro-American Collection</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/2">See All Blockson Collection Videos</a>
+			</span>
+			<div class="row">
+				<% @blockson.take(4).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+
+	<div class="row even">
+		<div class="col">
+			<h2>Livingstone Undergraduate Research Awards</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/3">See All Research Awards Videos</a>
+			</span>
+			<div class="row">
+				<% @awards.take(4).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+
+	<div class="row odd">
+		<div class="col">
+			<h2>Loretta C. Duckworth Scholars Studio</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/4">See All Scholars Studio Videos</a>
+			</span>
+			<div class="row">
+				<% @lcdss.take(4).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+
+
+  <% unless @scrc.empty? %>
+	<div class="row even">
+		<div class="col">
+			<h2>Special Collections Research Center</h2>
+			<span class="morevideos">
+				<a href="/watchpastprograms/list/5">See All Special Collections Videos</a>
+			</span>
+			<div class="row">
+				<% @scrc.take(4).each do |video| %>
+				<div class="col-12 col-md-6 col-lg-3 text-center" style="margin: 10px 0;max-width:300px;min-width:300px;">
+					<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+						<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;" %>
+						<br>
+						<%= video[:Title].truncate(64) %>
+					<% end %>
+				</div>
+				<% end %>
+			</div>
+		</div>
+	</div>
+	<% end %>
+
+	</div>
+
+<style>
+	.ev-navbar.mb-0.navbar-custom {
+		display: none;
+	}
+</style>

--- a/app/views/pages/videos_list.html.erb
+++ b/app/views/pages/videos_list.html.erb
@@ -1,0 +1,28 @@
+<div class="container" id="videos-index">
+
+	<div class="row" style="margin-top: 14px">
+		<div class="col">
+			<%= link_to "< Watch Past Programs & Events", pages_videos_all_path %> 
+		</div>
+	</div>
+
+	<div class="row" style="margin-top: 21px;">
+		<div class="col">
+			<h1 class="page-title">Past Program and Event Videos</h1>
+			<hr >
+			<h2><%= @categoryTitle %></h2>
+			<div class="row">
+			<% @videos[:Data].each do |video| %>
+			<div class="col-6 col-md-4 col-lg-3 text-center" style="margin-top: 14px">
+				<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+				<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), style: "max-height: 135px;", class: "decorative" %>
+				<br>
+				<%= video[:Title].truncate(64) %>
+		    <% end %>
+			</div>
+			<% end %>
+		</div>
+		</div>
+	</div>
+
+</div>

--- a/app/views/pages/videos_search.html.erb
+++ b/app/views/pages/videos_search.html.erb
@@ -1,0 +1,29 @@
+<div class="container">
+
+	<div class="row" style="margin-top: 14px">
+		<div class="col">
+			<%= link_to "< Watch Past Programs & Events", pages_videos_all_path %> 
+		</div>
+	</div>
+
+	<div class="row" style="margin-top: 21px;">
+		<div class="col">
+			<h1 class="page-title">Past Program and Event Videos</h1>
+			<hr >
+			<h2><%= @categoryTitle %></h2>
+			<div class="row">
+			<% @videos[:Data].each do |video| %>
+			<div class="col-6 col-md-4 col-lg-3 text-center">
+				<%= link_to pages_videos_show_path(id: video[:ID]) do %>
+				<%# binding.pry %>
+				<%= image_tag (video[:ThumbnailUrl].sub! "Width=100", "Width=240"), class: "decorative" %>
+				<br>
+				<%= video[:Title] %>
+		    <% end %>
+			</div>
+			<% end %>
+		</div>
+		</div>
+	</div>
+
+</div>

--- a/app/views/pages/videos_show.html.erb
+++ b/app/views/pages/videos_show.html.erb
@@ -1,0 +1,31 @@
+<div class="container">
+
+	<div class="row" style="margin-top: 14px">
+		<div class="col">
+			<%= link_to "< Watch Past Programs & Events", pages_videos_all_path %> 
+		</div>
+	</div>
+
+	<div class="row" style="margin-top: 21px;">
+		<div class="col">
+			<h1 class="page-title">Past Program and Event Videos</h1>
+				<div id="featuredTitle"><p><span><%= @featured_video_title %></span></p></div>
+		    <div id="ensembleEmbeddedContent_<%= @featured_video_id %>" class="ensembleEmbeddedContent" style="height: 680px;overflow:hidden;">
+	        <script type="text/javascript" style="position: relative;" src="https://ensemble.temple.edu/app/plugin/plugin.aspx?embed=true&contentID=<%= @featured_video_id %>&isResponsive=false&isNewPluginEmbed=true&useIFrame=false&displayTitle=false&startTime=0&autoPlay=false&hideControls=true&showCaptions=false&displaySharing=true&displayAnnotations=false&displayAttachments=false&displayLinks=false&displayEmbedCode=true&displayDownloadIcon=false&displayMetaData=false&displayDateProduced=false&audioPreviewImage=false&displayCaptionSearch=false"></script>
+		    </div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col">
+			<hr >
+			<%= sanitize @featured_video_description.html_safe %>
+		</div>
+	</div>
+</div>
+
+<style>
+	.ev-navbar.mb-0.navbar-custom {
+		display: none;
+	}
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,10 @@ Rails.application.routes.draw do
     get "home" => :home, as: "pages_home"
     get "lcdss" => :tudsc, as: "pages_lcdss"
     get "explore-charles" => :charles, as: "pages_charles"
+    get "watchpastprograms" => :videos_all, as: "pages_videos_all"
+    get "watchpastprograms/list/:collection" => :videos_list, as: "pages_videos_collection"
+    get "watchpastprograms/search" => :videos_search, as: "pages_videos_search"
+    get "watchpastprograms/show" => :videos_show, as: "pages_videos_show"
   end
 
   match "/404", to: "errors#not_found", via: :all


### PR DESCRIPTION
How do I get to the videos? I see a link on the /events page that says “Past events and recordings”, but I don’t see the recordings.
*********************
Assuming these changes were lost in a conflict resolution.

- Re-enabled button for display.
- Updated link on button to videos main page.