### PR TITLE
#MAN-166 List of Videos

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -21,7 +21,7 @@
         <%= link_to @mailing_list do %>
         <h2>
           <%= image_tag "email.png", class: "category-icon decorative"  %>
-          <br />Signup for our mailing list
+          <br />Sign Up for our mailing list
         </h2>
         <% end %>
       </div>
@@ -52,7 +52,7 @@
       </div>
 
       <div>
-        <%= link_to t("manifold.events.view_past_events_videos"), events_path, class: "video-button" %>
+        <%= link_to t("manifold.events.view_past_events_videos"), pages_videos_all_path, class: "video-button" %>
       </div>
 
       <div class="exhibit">


### PR DESCRIPTION
How do I get to the videos? I see a link on the /events page that says “Past events and recordings”, but I don’t see the recordings.
***************
Assuming these were lost in a conflict resolution:

- Enabled video button. 
- Updated link on video button.