### PR TITLE
#MAN-447 Collection entity external link display

### DIFF
--- a/app/assets/stylesheets/collections.scss
+++ b/app/assets/stylesheets/collections.scss
@@ -33,4 +33,16 @@
 			margin-top: 35px;
 		}
 	}
+	.collections-external-link {
+		background-color: #A50030;
+    padding: 21px;
+    color: #fff !important;
+    text-align: center;
+    border-radius: 7px;
+    display: inline-block;
+    width: 100%;
+    margin-bottom: 14px;
+    text-decoration: underline;
+    text-align: left;
+  }
 }

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -44,6 +44,11 @@
         <div class="access-link">
           <h2><%= link_to "Explore this Collection", finding_aids_path(collection: @collection) %></h2>
         </div>
+        <% unless @collection.external_link.nil? %>
+        <div>
+          <h2><%= link_to @collection.external_link.title, @collection.external_link.link, class: "collections-external-link" %></h2>
+        </div>
+        <% end %>
       </div>
 
   </div>


### PR DESCRIPTION
We added an external link field to the collection entity. However, there is no display for the external link.

Where we would normally have the external link, we currently have an "Explore this collection" button that goes to the finding aid index page. This should stay and we should figure out another way to include the external link.
*************
Added external link button below the Explore button.