### PR TITLE
#MAN-640 Remove link requirement in alert

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -138,3 +138,7 @@ img.map {
 blockquote {
 	margin: 21px;
 }
+
+marquee {
+	color: $red;
+}

--- a/app/views/application/_header_navbar.html.erb
+++ b/app/views/application/_header_navbar.html.erb
@@ -41,7 +41,7 @@
                 <% unless alert.link.blank? %>
                   <%= link_to alert.scroll_text+", click here to see full details...", alert.link %>
                 <% else %>
-                  <%= link_to alert.scroll_text+", click here to see full details...", alerts_path, id: alert.id %>
+                  <%= alert.scroll_text %>
                 <% end %>
               <% end %>
             </marquee>


### PR DESCRIPTION
I tried to create an alert without a link and got a 509 error. Can you remove the requirement for a link and remove the text that says "click for more details" and instead show the entire text of the alert.
****************
Error was caused by default link (when custom link is not supplied) being routed to the show page for the alert.  Since we don't have, or want, show pages for alerts, the link was removed entirely when there is no custom link. The alert will then not be a link and the "click for more details..." text will also not show. 