### PR TITLE
#MAN-474 Add h1 header with index page name to desktop and mobile

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,1 +1,2 @@
+<h1 class="sr-only">About</h1>
 <%= render "categories" %>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,5 +1,5 @@
 <% content_for :body_class, "categories" %>
-
+<h1 class="sr-only">Contact Us</h1>
 <div class="container contact-us" style="margin-top: 35px;">
 
 	<div class="row text-center">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
+<h1 class="sr-only">Home</h1>
 <div id="home">
 <div id="searchFields">
 

--- a/app/views/pages/marketing.html.erb
+++ b/app/views/pages/marketing.html.erb
@@ -1,5 +1,0 @@
-<% if params[:type] == "floorplans" %>
-	<%= render "pages/marketing/floorplans" %>
-<% else %>
-	<%= render "pages/marketing/renderings" %>
-<% end %>

--- a/app/views/pages/research.html.erb
+++ b/app/views/pages/research.html.erb
@@ -1,1 +1,2 @@
+<h1 class="sr-only">Research Services</h1>
 <%= render "categories" %>

--- a/app/views/pages/visit.html.erb
+++ b/app/views/pages/visit.html.erb
@@ -1,1 +1,2 @@
+<h1 class="sr-only">Visit</h1>
 <%= render "categories" %>


### PR DESCRIPTION
Add h1 header with index page name. As of now, there is no indication of where the user has landed in the site when they get to About, Visit & Study, etc.
**********
Added H1 for screen readers, main menu already indicates which page users are on.