### PR TITLE
#MAN-436 Finding aid index page - link to prefaceted finding aid search

### DIFF
--- a/app/assets/stylesheets/finding_aids.scss
+++ b/app/assets/stylesheets/finding_aids.scss
@@ -96,3 +96,16 @@
 		color: $seagreen!important;
 	}
 }
+
+.catalog-link {
+	background-color: $seagreen;
+  padding: 21px;
+  color: #fff !important;
+  text-align: center;
+  border-radius: 7px;
+  display: inline-block;
+  width: 100%;
+  margin-bottom: 14px;
+  text-decoration: underline;
+  text-align: left;
+}

--- a/app/assets/stylesheets/finding_aids.scss
+++ b/app/assets/stylesheets/finding_aids.scss
@@ -98,7 +98,7 @@
 }
 
 .catalog-link {
-	background-color: $seagreen;
+  background-color: $seagreen;
   padding: 21px;
   color: #fff !important;
   text-align: center;

--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -8,6 +8,7 @@ class FindingAidsController < ApplicationController
 
   def index
     @finding_aids = FindingAid.all
+    @catalog_search = "#{Rails.configuration.librarysearch_finding_aids_url}"
 
     respond_to do |format|
       format.html

--- a/app/views/finding_aids/index.html.erb
+++ b/app/views/finding_aids/index.html.erb
@@ -19,8 +19,12 @@
 			</div>
     </div>
 
-    <div class="col-12 col-lg-9" style="padding-left: 28px;">
+    <div class="col-12 col-lg-6" style="padding-left: 28px;">
       <%= render "aid_list" %>
+    </div>
+
+    <div class="col-12 col-lg-3" style="padding-left: 28px;">
+      <h2><%= link_to "Search All Finding Aids", @catalog_search, class: "catalog-link" %></h2>
     </div>
   </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module Tude
     # the framework and any gems in your application.
 
     config.librarysearch_base_url = "https://#{ENV.fetch('LIBRARYSEARCH_DOMAIN', 'librarysearch.temple.edu')}"
+    config.librarysearch_finding_aids_url = "#{config.librarysearch_base_url}/web_content?f%5Bweb_content_type_facet%5D%5B%5D=Finding+Aids"
     config.group_types = ["Assembly",
                           "Committee",
                           "Department",


### PR DESCRIPTION
On the finding aid index page /finding_aids, please add a CTA button/link to library search that is pre-faceted for finding aids, either from Alma or from manifold. 
**************
Added link to config and called that in the view.