### PR TITLE
#MAN-492 Past events most recent events first

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -20,6 +20,7 @@ class EventsController < ApplicationController
   def past
     events = @all_events.having("start_time < ?", @today).order(start_time: :desc)
     @events = return_events(events)
+    @intro = Page.find_by_slug("events-intro")
     respond_to do |format|
       format.html
       format.json { render json: EventSerializer.new(@events) }
@@ -57,7 +58,11 @@ class EventsController < ApplicationController
     end
 
     unless @events.blank?
-      events_list = Event.where(id: @events.map(&:id)).order(:start_time)
+      unless action_name == "past"
+        events_list = Event.where(id: @events.map(&:id)).order(:start_time)
+      else
+        events_list = Event.where(id: @events.map(&:id)).order(start_time: :desc)
+      end
       @events_list = events_list.page params[:page]
     else
       @events_list = events.page params[:page]

--- a/app/views/events/past.html.erb
+++ b/app/views/events/past.html.erb
@@ -3,7 +3,9 @@
 <div class="container event-index">
 
   <h1 class="d-none d-lg-block"><%= t("manifold.events.page_title") %></h1>
-  <p class="d-lg-block"><%= t("manifold.events.explanation").html_safe %></p>
+  <% unless @intro.nil? %>
+    <div class="intro px-4"><%= sanitize @intro.description.html_safe %></div>
+  <% end %>
 
   <div class="row">
     <div class="col-3 leftside-index d-none d-md-none d-lg-block">


### PR DESCRIPTION
In the /events/past list, when I click on a filter, the events listing starts with 2015. I'm assuming that 2015 is as far back as we go. 

Example: https://web.qa.tul-infra.page/events/past?page=1&type=Performance

I would like to see the most recent past events first. 
************
Also added intro text to past events page.