### PR TITLE
#MAN-557 re: give us your feedback

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -216,7 +216,7 @@ class PagesController < ApplicationController
   def contact
     @fcn_link = Page.find_by_slug("numbers")
     @libanswers = ExternalLink.find_by_slug("libanswers")
-    @suggestions = Blog.find_by_slug("suggestions").base_url
+    @suggestions = ExternalLink.find_by_slug("suggestions")
   end
 
   def show

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -55,7 +55,7 @@
 		</div>
 
 		<div class="col-12 col-md-6 col-lg-4">
-			<%= link_to strip_tags(@suggestions) do %>
+			<%= link_to @suggestions do %>
 			<h2>
 				<%= image_tag "feedback.png", class: "category-icon decorative"  %>
 				<br />Give Us Your Feedback


### PR DESCRIPTION
The "feedback" link on the contact page goes to the What's Your Suggestion blog page.

I think it would be better to make that the link to the form you fill out to submit the feedback - rather than have the customer look for the link on the blog page;

https://sites.temple.edu/librarysuggestions/suggest/
**************
Change instance variable to use external link already setup.