### PR TITLE
#MAN-243 Cleaner support for MIssing hours

### DIFF
--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -3,6 +3,10 @@
 class LibraryHoursController < ApplicationController
   before_action :buildings, :set_dates, only: [:index, :show]
 
+  def show
+    redirect_to action: "index"
+  end
+
   def index
     @buildings.each do |building|
       building[:spaces].map! do |space|


### PR DESCRIPTION
https://app.honeybadger.io/projects/58150/faults/41585809#notice-summary

ActionView::Template::Error: undefined method `first' for nil:NilClass

This error was thrown because we don't have hours for this space. We should redirect to a 404 if we don't have that space, not error out like this.
*********************
Added the show action back to the controller to handle requests for hours pages (locations) we do not have -- which would be all locations requested since we only have an index for this controller. The previous behavior was to display a blank page with our header and footer and this looked like a mistake.