### PR TITLE
#MAN-659 Selected Filters in Finding Aids

### DIFF
--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -47,6 +47,7 @@ class FindingAidsController < ApplicationController
     @collections = aids.select { |aid| aid.collections.try(:any?) }.collect { |c| c.collections }.flatten.uniq.sort
   end
 
+
   private
     def set_finding_aid
       @finding_aid = FindingAid.find(params[:id])

--- a/app/helpers/finding_aids_helper.rb
+++ b/app/helpers/finding_aids_helper.rb
@@ -24,4 +24,42 @@ module FindingAidsHelper
     end
     tags
   end
+
+
+  def subject_links
+    links = []
+    unselected_links = []
+    unless @subjects.nil?
+      unless params[:subject].nil?
+
+        @subjects.each do |subject|
+          subjects = params[:subject].split(",")
+          if params[:subject].include?(subject)
+            subject_removed = subjects.reject { |sub| sub == subject }.uniq.join(",")
+            link = '<li class="active"> ' + subject + '
+                      <span class="clear-filter">
+                        <a href="' + finding_aids_path(request.query_parameters.merge(subject: subject_removed, page: 1)) + '">X</a>
+                      </span>
+                    </li>'
+            links << link
+          else
+            subjects = subjects.split(",").push(subject).uniq.join(",")
+            link = '<li><a href="' + finding_aids_path(request.query_parameters.merge(subject: subjects, page: 1)) + '"> ' + subject + "</a></li>"
+            unselected_links << link
+          end
+        end
+
+      else
+        @subjects.each do |subject|
+          link = '<li><a href="' + finding_aids_path(request.query_parameters.merge(subject: subject, page: 1)) + '"> ' + subject + "</a></li>"
+          links << link
+        end
+      end
+    end
+
+    unselected_links.each do |link| #keeps selected filters at top of list
+      links << link
+    end
+    links
+  end
 end

--- a/app/views/finding_aids/_subjects.html.erb
+++ b/app/views/finding_aids/_subjects.html.erb
@@ -4,44 +4,8 @@
   </a>
 </h2>
 
-  <ul class="list-unstyled navbar-collapse collapse show" id="subjects">
-  	<% unless @subjects.nil? %>
-	  	<% unless params[:subject].nil? %>
-	  	
-			<% @subjects.each do |subject| %>
-		  	<% subjects = params[:subject].split(',') %>
-
-				<% if params[:subject].include?(subject) %>
-
-					<% subject_removed = subjects.reject{ |sub| sub == subject }.uniq.join(',') %>
-
-					<li class="active"><%= subject %>
-						<span class="clear-filter">
-							<%= link_to "X", finding_aids_path(request.query_parameters.merge({subject: subject_removed, page: 1})) %>
-						</span>
-					</li>
-
-				<% else %>
-
-					<% subjects = subjects.split(',').push(subject).uniq.join(',') %>
-
-					<li><%= link_to subject, finding_aids_path(request.query_parameters.merge({subject: subjects, page: 1})) %></li>
-
-				<% end %>
-
-			<% end %>
-
-		<% else %>
-
-			<% @subjects.each do |subject| %>
-
-				<li>
-					<%= link_to subject, finding_aids_path(request.query_parameters.merge({subject: subject, page: 1})) %>
-				</li>
-
-			<% end %>
-
-		<% end %>
-
-		<% end %>
-	</ul>
+<ul class="list-unstyled navbar-collapse collapse show" id="subjects">
+	<% subject_links.each do |link| %>
+		<%= link.html_safe %>
+	<% end %>
+</ul>


### PR DESCRIPTION
Not all the filters selected are displayed in desktop view of finding aids index page. They are all shown in mobile view.

This seems hit or miss as you continue to select more subject filters.
*********************
Refactoring the view to use a helper seems to have eliminated the disappearing filter options.