### PR TITLE
#WEB-2916 Patron forms on library website

### DIFF
--- a/app/views/forms/_all.html.erb
+++ b/app/views/forms/_all.html.erb
@@ -10,7 +10,7 @@
     </div>
 
   <div class="row">
-    <div class="col text-center" style="font-size: larger;margin-bottom: 35px">
+    <div class="col text-center" style="font-size: larger;margin-bottom: 21px">
       <p align="center">Use of these forms is intended for and restricted to members of the Temple University Community</p>
       <p><a href="/contact-us">Library Suggestions/Feedback</a></p>
     </div>
@@ -39,15 +39,6 @@
       <h2>Library Privileges</h2>
       <ul class="list-unstyled">
         <li>
-          <a href="/forms/adjunct-privileges">Activate Adjunct Faculty Privileges (if not currently under contract)</a>
-        </li>
-        <li>
-          <a href="/forms/visiting-privileges">Library Borrowing Privileges for Departmental Guests, Visiting Scholars, Interns, Non-registered students, etc.</a>
-        </li>
-        <li>
-          <a href="/forms/partners-borrowing">Partners Borrowing Privileges Application/Renewal</a>
-        </li>
-        <li>
           <a href="/forms/proxy-account">Proxy Account</a>
         </li>
         </ul>
@@ -61,9 +52,6 @@
         <ul class="list-unstyled">
           <li>
             <a href="/forms/table-request">Library Staff and Registered Student Organization Table Request</a>
-          </li>
-          <li>
-            <a href="/forms/submit-a-slide">Submit a Slide for Display on Library Monitors</a>
           </li>
         </ul>
 
@@ -80,15 +68,6 @@
           </li>
           <li>
             For books not available through E-ZBorrow, <em>as well as journal articles</em>, and other materials not available here, use <a class="inline" href="http://libproxy.temple.edu/login?url=https://temple.illiad.oclc.org/illiad/paley/logon.html">ILLiad</a>, our new service for requesting hard to find materials.
-          </li>
-        </ul>
-        <h2>Other Forms</h2>
-        <ul class="list-unstyled">
-          <li>
-            <a href="/forms/3d-printing">3D Printing Request Form</a>
-          </li>
-          <li>
-            <a href="/forms/staff/">Library Staff Forms -- Staff Use Only</a>
           </li>
         </ul>
     </div>


### PR DESCRIPTION
When I asked you to add the Partners borrowing request form back to the
website, I should have also asked for you to remove the now unnecessary
forms:
***************
Removed all links from the page that we do not have forms for.