### PR TITLE
#MAN-670 Increase the number of results per page in staff directory

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,7 +7,7 @@ class Person < ApplicationRecord
   include Categorizable
   include Imageable
 
-  paginates_per 5
+  paginates_per 20
 
   validates :first_name, :last_name, :job_title, presence: true
   validates :email_address, presence: true, email: true


### PR DESCRIPTION
Increase the number of results per page to 20 instead of 5. 