### PR TITLE
#MAN-694 Events on the LCDSS homepage

### DIFF
--- a/app/views/pages/tudsc.html.erb
+++ b/app/views/pages/tudsc.html.erb
@@ -80,8 +80,8 @@
 				<div class="links d-none d-lg-block">
 					<h2>Workshops & Events</h2>
 					<ul class="list-unstyled">
-						<% unless @events_links.nil? %>
-						<% @events_links.each do |link| %>
+						<% unless @event_links.nil? %>
+						<% @event_links.each do |link| %>
 							<li><%= link_to link.label, link %></li>
 						<% end %>
 						<% end %>


### PR DESCRIPTION
Events are not showing on the LCDSS homepage.
****************
Put "Digital Scholarship" into any event's tags and it should show up on the LCDSS homepage under Workshops & Events.