### PR TITLE
#MAN-673 aeon api tweak

### DIFF
--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -53,6 +53,6 @@ class FindingAidsController < ApplicationController
       @finding_aid = FindingAid.find(params[:id])
       @title = @finding_aid.label
       blockson = Collection.find_by_slug("blockson_collection")
-      @aeon = collections.include?(blockson) ? true : false
+      @aeon = @finding_aid.collections.include?(blockson)
     end
 end

--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -51,5 +51,8 @@ class FindingAidsController < ApplicationController
   private
     def set_finding_aid
       @finding_aid = FindingAid.find(params[:id])
+      @title = @finding_aid.label
+      blockson = Collection.find_by_slug("blockson_collection")
+      @aeon = collections.include?(blockson) ? true : false
     end
 end

--- a/app/dashboards/collection_dashboard.rb
+++ b/app/dashboards/collection_dashboard.rb
@@ -22,6 +22,7 @@ class CollectionDashboard < Administrate::BaseDashboard
     add_to_footer: Field::Boolean.with_options(admin_only: true),
     categories: Field::HasMany,
     external_link: Field::BelongsTo,
+    slug: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -44,6 +45,7 @@ class CollectionDashboard < Administrate::BaseDashboard
     :subject,
     :space,
     :categories,
+    :slug,
     :external_link
   ].freeze
 
@@ -52,6 +54,7 @@ class CollectionDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
+    :slug,
     :image,
     :description,
     :subject,

--- a/app/views/finding_aids/show.html.erb
+++ b/app/views/finding_aids/show.html.erb
@@ -37,9 +37,11 @@
 
     <div class="col-12 col-lg-3">
       <% unless @finding_aid.collections.blank? && @finding_aid.identifier.blank? %>
+      <% unless @aeon %>
       <div class="access-link">
         <h2><%= link_to "Request Materials from Special Collections Research Center", "https://temple.aeon.atlas-sys.com/Logon/?Action=10&Form=30&ItemTitle=#{@finding_aid.name}&ItemPlace=#{@finding_aid.collections.first.name}&CallNumber=#{@finding_aid.identifier}&rft.pages=#{@finding_aid.collections.first.name}" %></h2>
       </div>
+      <% end %>
       <% end %>
     </div>
   </div>

--- a/db/migrate/20190926180617_add_slug_field_to_collections.rb
+++ b/db/migrate/20190926180617_add_slug_field_to_collections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSlugFieldToCollections < ActiveRecord::Migration[5.2]
+  def change
+    add_column :collections, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_06_225436) do
+ActiveRecord::Schema.define(version: 2019_09_26_180617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,6 +151,7 @@ ActiveRecord::Schema.define(version: 2019_08_06_225436) do
     t.boolean "add_to_footer"
     t.integer "space_id"
     t.bigint "external_link_id"
+    t.string "slug"
     t.index ["building_id"], name: "index_collections_on_building_id"
     t.index ["external_link_id"], name: "index_collections_on_external_link_id"
     t.index ["space_id"], name: "index_collections_on_space_id"
@@ -330,6 +331,7 @@ ActiveRecord::Schema.define(version: 2019_08_06_225436) do
     t.string "personal_site"
     t.string "springshare_id"
     t.string "specialties"
+    t.string "libguides_account"
   end
 
   create_table "policies", force: :cascade do |t|


### PR DESCRIPTION
Once the new migration is in place, the slug field for the Blockson Collection collection will need the "blockson_collection" identifier added to it.

Then you will not see the Request this item.... link button on any blockson finding aids.

Find blockson aids here: /finding_aids?collection=10