### PR TITLE
#MAN-675 building name helper function can't take nil as param

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -52,6 +52,8 @@ module EventHelper
     raw(event_rdf.to_json)
   end
   def get_bldg_name(bldg_name)
-    t("manifold.default.event.#{bldg_name.parameterize.underscore}", default: bldg_name)
+    unless bldg_name.nil?
+      t("manifold.default.event.#{bldg_name.parameterize.underscore}", default: bldg_name)
+    end
   end
 end

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -14,7 +14,9 @@
         <% unless event.building.nil? %>
           | <%= get_bldg_name(event.building.name) %>
         <% else %>
-          | <%= get_bldg_name(event.external_building) %>
+          <% unless event.external_building.nil? %>
+          | <%= event.external_building %>
+          <% end %>
         <% end %>
       </strong></p>
       <p><%= sanitize strip_tags(event.description.html_safe.truncate(250)) %></p>
@@ -33,7 +35,7 @@
           <%= link_to get_bldg_name(event.building.name), event.building, class: "event_location" %>
         <% else %>
           <% unless event.external_building.nil? %>
-            <span class="event_location"><%= get_bldg_name(event.external_building) %></span> 
+            <span class="event_location"><%= event.external_building %></span> 
           <% end %>
         <% end %>
       </p>

--- a/app/views/events/_facets.html.erb
+++ b/app/views/events/_facets.html.erb
@@ -42,6 +42,7 @@
     </h2>
     <ul class="list-unstyled navbar-collapse collapse show" id="locations">
       <% @event_locations.each do |location| %>
+      <% unless location.empty? %>
         <% unless action_name == "past" %>
           <li<% if location == params[:location] %><% active = true %> class="active"<% end %>>
             <%= link_to get_bldg_name(location), events_path(request.query_parameters.merge({location: location, page: 1})) %>
@@ -62,6 +63,7 @@
           <% active = false %>
         <% end %>
           </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -64,5 +64,10 @@ RSpec.describe EventHelper, type: :helper do
         expect(helper.get_bldg_name("Kahn Hall")).to eq("Kahn Hall")
       end
     end
+    context "receives nil" do
+      it "skips the render which would throw an error" do
+        expect(helper.get_bldg_name(nil)).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Events without locations (nil building and blank external building) were erroring the view since that nil, or blank, was being passed to the filter helper which populates the filters.

Empty locations are now handled so that they pass through without triggering the filter helpers.

Test this here: https://library.temple.edu/events/past?page=99 (if no error, fix is good)