### PR TITLE
Add finding aid feature specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,5 @@ group :test do
   gem "selenium-webdriver"
   gem "simplecov", require: false
   gem "webmock"
+  gem "launchy"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,8 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     link_header (0.0.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -451,7 +453,7 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -577,6 +579,7 @@ DEPENDENCIES
   json-ld
   json-schema
   kaminari
+  launchy
   listen (>= 3.0.5, < 3.2)
   lockbox
   mail_form

--- a/spec/features/finding_aids_spec.rb
+++ b/spec/features/finding_aids_spec.rb
@@ -86,4 +86,47 @@ RSpec.feature "FindingAids", type: :feature do
       expect(page).to_not have_content(@other_finding_aid.name)
     end
   end
+
+  context "Collecting and Subject Area" do
+    Capybara.ignore_hidden_elements = false
+    before(:all) do
+      @collection_1 = FactoryBot.create(:collection, name: "Collection 1")
+      @collection_2 = FactoryBot.create(:collection, name: "Collection 2")
+      @collection_3 = FactoryBot.create(:collection, name: "Collection 3")
+      @finding_aid_1 = FactoryBot.create(:finding_aid, name: "Finding Aid 1", subject: ["subject_1"],
+                                         collections: [@collection_1])
+      @finding_aid_2 = FactoryBot.create(:finding_aid, name: "Finding Aid 2", subject: ["subject_1"],
+                                         collections: [@collection_2])
+      @finding_aid_3 = FactoryBot.create(:finding_aid, name: "Finding Aid 3", subject: ["subject_2"],
+                                         collections: [@collection_3])
+    end
+
+    after(:all) do
+      Collection.delete_all
+      FindingAid.delete_all
+    end
+
+    scenario "Filter by Collection, then by Subject" do
+      visit("/finding_aids")
+      expect(page).to have_content(@finding_aid_1.name)
+      expect(page).to have_content(@finding_aid_2.name)
+      expect(page).to have_content(@finding_aid_3.name)
+      within(".aid-index") do
+        within(".filter_subjects") do
+          click_on @finding_aid_1.subject.first
+        end
+      end
+      expect(page).to have_content(@finding_aid_1.name)
+      expect(page).to have_content(@finding_aid_2.name)
+      expect(page).to_not have_content(@finding_aid_3.name)
+      within(".aid-index") do
+        within(".filter_collections") do
+          click_on @collection_1.name
+        end
+      end
+      expect(page).to have_content(@finding_aid_1.name)
+      expect(page).to_not have_content(@finding_aid_2.name)
+      expect(page).to_not have_content(@finding_aid_3.name)
+    end
+  end
 end

--- a/spec/features/finding_aids_spec.rb
+++ b/spec/features/finding_aids_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature "FindingAids", type: :feature do
+  context "Finding Aids Home Page" do
+
+    scenario "Should be click on the a search all finding aids button" do
+      visit("/finding_aids")
+      expect(page).to have_content("Search All Finding Aids")
+    end
+
+  end
+
+  context "Collecting Area" do
+    Capybara.ignore_hidden_elements = false
+    before(:all) do
+      @collection = FactoryBot.create(:collection)
+      @other_collection = FactoryBot.create(:collection, name: "Other Collection")
+      @finding_aid = FactoryBot.create(:finding_aid, collections: [@collection, @other_collection])
+    end
+
+    after(:all) do
+      Collection.delete_all
+      FindingAid.delete_all
+    end
+
+    scenario "Visit finding aid that has an collection" do
+      visit("/finding_aids")
+      within(".aid-index") do
+        within(".filter_collections") do
+          expect(page).to have_content(@collection.name)
+          expect(page).to have_content(@other_collection.name)
+        end
+      end
+    end
+
+    scenario "Filter by Collection" do
+      visit("/finding_aids")
+      within(".aid-index") do
+        within(".filter_collections") do
+          click_on @collection.name
+          expect(page).to have_content(@collection.name)
+          expect(page).to_not have_content(@other_collection.name)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/finding_aids_spec.rb
+++ b/spec/features/finding_aids_spec.rb
@@ -15,7 +15,8 @@ RSpec.feature "FindingAids", type: :feature do
     before(:all) do
       @collection = FactoryBot.create(:collection)
       @other_collection = FactoryBot.create(:collection, name: "Other Collection")
-      @finding_aid = FactoryBot.create(:finding_aid, collections: [@collection, @other_collection])
+      @finding_aid = FactoryBot.create(:finding_aid, name:"Finding Aid 1", collections: [@collection])
+      @other_finding_aid = FactoryBot.create(:finding_aid, name:"Finding Aid 2", collections: [@other_collection])
     end
 
     after(:all) do
@@ -31,6 +32,8 @@ RSpec.feature "FindingAids", type: :feature do
           expect(page).to have_content(@other_collection.name)
         end
       end
+      expect(page).to have_content(@finding_aid.name)
+      expect(page).to have_content(@other_finding_aid.name)
     end
 
     scenario "Filter by Collection" do
@@ -42,6 +45,45 @@ RSpec.feature "FindingAids", type: :feature do
           expect(page).to_not have_content(@other_collection.name)
         end
       end
+      expect(page).to have_content(@finding_aid.name)
+      expect(page).to_not have_content(@other_finding_aid.name)
+    end
+  end
+
+  context "Subject Area" do
+    Capybara.ignore_hidden_elements = false
+    before(:all) do
+      @finding_aid = FactoryBot.create(:finding_aid, name: "Finding Aid 1")
+      @other_finding_aid = FactoryBot.create(:finding_aid, name: "Finding Aid 2", subject: ["other_subject"])
+    end
+
+    after(:all) do
+      FindingAid.delete_all
+    end
+
+    scenario "Visit finding aid that has an subject" do
+      visit("/finding_aids")
+      within(".aid-index") do
+        within(".filter_subjects") do
+          expect(page).to have_content(@finding_aid.subject.first)
+          expect(page).to have_content(@other_finding_aid.subject.first)
+        end
+      end
+      expect(page).to have_content(@finding_aid.name)
+      expect(page).to have_content(@other_finding_aid.name)
+    end
+
+    scenario "Filter by Subject" do
+      visit("/finding_aids")
+      within(".aid-index") do
+        within(".filter_subjects") do
+          click_on @finding_aid.subject.first
+          expect(page).to have_content(@finding_aid.subject.first)
+          expect(page).to_not have_content(@other_finding_aid.subject.first)
+        end
+      end
+      expect(page).to have_content(@finding_aid.name)
+      expect(page).to_not have_content(@other_finding_aid.name)
     end
   end
 end

--- a/spec/features/finding_aids_spec.rb
+++ b/spec/features/finding_aids_spec.rb
@@ -1,104 +1,23 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.feature "FindingAids", type: :feature do
   context "Finding Aids Home Page" do
 
-    scenario "Should be click on the a search all finding aids button" do
-      visit("/finding_aids")
-      expect(page).to have_content("Search All Finding Aids")
-    end
-
-  end
-
-  context "Collecting Area" do
-    Capybara.ignore_hidden_elements = false
-    before(:all) do
-      @collection = FactoryBot.create(:collection)
-      @other_collection = FactoryBot.create(:collection, name: "Other Collection")
-      @finding_aid = FactoryBot.create(:finding_aid, name:"Finding Aid 1", collections: [@collection])
-      @other_finding_aid = FactoryBot.create(:finding_aid, name:"Finding Aid 2", collections: [@other_collection])
-    end
-
-    after(:all) do
-      Collection.delete_all
-      FindingAid.delete_all
-    end
-
-    scenario "Visit finding aid that has an collection" do
-      visit("/finding_aids")
-      within(".aid-index") do
-        within(".filter_collections") do
-          expect(page).to have_content(@collection.name)
-          expect(page).to have_content(@other_collection.name)
-        end
-      end
-      expect(page).to have_content(@finding_aid.name)
-      expect(page).to have_content(@other_finding_aid.name)
-    end
-
-    scenario "Filter by Collection" do
-      visit("/finding_aids")
-      within(".aid-index") do
-        within(".filter_collections") do
-          click_on @collection.name
-          expect(page).to have_content(@collection.name)
-          expect(page).to_not have_content(@other_collection.name)
-        end
-      end
-      expect(page).to have_content(@finding_aid.name)
-      expect(page).to_not have_content(@other_finding_aid.name)
-    end
-  end
-
-  context "Subject Area" do
-    Capybara.ignore_hidden_elements = false
-    before(:all) do
-      @finding_aid = FactoryBot.create(:finding_aid, name: "Finding Aid 1")
-      @other_finding_aid = FactoryBot.create(:finding_aid, name: "Finding Aid 2", subject: ["other_subject"])
-    end
-
-    after(:all) do
-      FindingAid.delete_all
-    end
-
-    scenario "Visit finding aid that has an subject" do
-      visit("/finding_aids")
-      within(".aid-index") do
-        within(".filter_subjects") do
-          expect(page).to have_content(@finding_aid.subject.first)
-          expect(page).to have_content(@other_finding_aid.subject.first)
-        end
-      end
-      expect(page).to have_content(@finding_aid.name)
-      expect(page).to have_content(@other_finding_aid.name)
-    end
-
-    scenario "Filter by Subject" do
-      visit("/finding_aids")
-      within(".aid-index") do
-        within(".filter_subjects") do
-          click_on @finding_aid.subject.first
-          expect(page).to have_content(@finding_aid.subject.first)
-          expect(page).to_not have_content(@other_finding_aid.subject.first)
-        end
-      end
-      expect(page).to have_content(@finding_aid.name)
-      expect(page).to_not have_content(@other_finding_aid.name)
-    end
-  end
-
-  context "Collecting and Subject Area" do
-    Capybara.ignore_hidden_elements = false
     before(:all) do
       @collection_1 = FactoryBot.create(:collection, name: "Collection 1")
       @collection_2 = FactoryBot.create(:collection, name: "Collection 2")
       @collection_3 = FactoryBot.create(:collection, name: "Collection 3")
-      @finding_aid_1 = FactoryBot.create(:finding_aid, name: "Finding Aid 1", subject: ["subject_1"],
+      @finding_aid_1 = FactoryBot.create(:finding_aid, name: "Finding Aid 1",
+                                         subject: ["subject 1"],
                                          collections: [@collection_1])
-      @finding_aid_2 = FactoryBot.create(:finding_aid, name: "Finding Aid 2", subject: ["subject_1"],
+      @finding_aid_2 = FactoryBot.create(:finding_aid, name: "Finding Aid 2",
+                                         subject: ["subject 2"],
                                          collections: [@collection_2])
-      @finding_aid_3 = FactoryBot.create(:finding_aid, name: "Finding Aid 3", subject: ["subject_2"],
-                                         collections: [@collection_3])
+      @finding_aid_1a = FactoryBot.create(:finding_aid, name: "Finding Aid 1a",
+                                          subject: ["subject 1"],
+                                          collections: [@collection_3])
     end
 
     after(:all) do
@@ -106,27 +25,81 @@ RSpec.feature "FindingAids", type: :feature do
       FindingAid.delete_all
     end
 
-    scenario "Filter by Collection, then by Subject" do
-      visit("/finding_aids")
-      expect(page).to have_content(@finding_aid_1.name)
-      expect(page).to have_content(@finding_aid_2.name)
-      expect(page).to have_content(@finding_aid_3.name)
-      within(".aid-index") do
-        within(".filter_subjects") do
-          click_on @finding_aid_1.subject.first
+    context "Collecting Area" do
+      scenario "Visit finding aid that has an collection" do
+        visit("/finding_aids")
+        within(".aid-index") do
+          within(".filter_collections") do
+            expect(page).to have_content(@collection_1.name)
+            expect(page).to have_content(@collection_2.name)
+          end
         end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to have_content(@finding_aid_2.name)
       end
-      expect(page).to have_content(@finding_aid_1.name)
-      expect(page).to have_content(@finding_aid_2.name)
-      expect(page).to_not have_content(@finding_aid_3.name)
-      within(".aid-index") do
-        within(".filter_collections") do
-          click_on @collection_1.name
+
+      scenario "Filter by Collection" do
+        visit("/finding_aids")
+        within(".aid-index") do
+          within(".filter_collections") do
+            click_on @collection_1.name
+            expect(page).to have_content(@collection_1.name)
+            expect(page).to_not have_content(@collection_2.name)
+          end
         end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to_not have_content(@finding_aid_2.name)
       end
-      expect(page).to have_content(@finding_aid_1.name)
-      expect(page).to_not have_content(@finding_aid_2.name)
-      expect(page).to_not have_content(@finding_aid_3.name)
+    end
+
+    context "Subject Area" do
+      scenario "Visit finding aid that has an subject" do
+        visit("/finding_aids")
+        within(".aid-index") do
+          within(".filter_subjects") do
+            expect(page).to have_content(@finding_aid_1.subject.first)
+            expect(page).to have_content(@finding_aid_2.subject.first)
+          end
+        end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to have_content(@finding_aid_2.name)
+      end
+
+      scenario "Filter by Subject" do
+        visit("/finding_aids")
+        within(".aid-index") do
+          within(".filter_subjects") do
+            click_on @finding_aid_1.subject.first
+            expect(page).to have_content(@finding_aid_1.subject.first)
+            expect(page).to_not have_content(@finding_aid_2.subject.first)
+          end
+        end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to_not have_content(@finding_aid_2.name)
+      end
+    end
+
+    context "Collecting and Subject Area" do
+      scenario "Filter by Collection, then by Subject" do
+        visit("/finding_aids")
+        within(".aid-index") do
+          within(".filter_subjects") do
+            click_on @finding_aid_1.subject.first
+          end
+        end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to_not have_content(@finding_aid_2.name)
+        expect(page).to have_content(@finding_aid_1a.name)
+        within(".aid-index") do
+          within(".filter_collections") do
+            click_on @collection_1.name
+          end
+        end
+        expect(page).to have_content(@finding_aid_1.name)
+        expect(page).to_not have_content(@finding_aid_2.name)
+        expect(page).to_not have_content(@finding_aid_1a.name)
+      end
     end
   end
+
 end


### PR DESCRIPTION
Issue MAN-674 Add feature tests for Finding Aids

We need to test the finding aids index page, specifically the filters, to ensure that future refactorings do not change expected behavior.

Specific tests include:In the right side filter menu

1) When you select a collecting areaa) it filters to finding aids in that collecting areab) the Subjects available to select are only those from the filtered finding aids

2) when you select a subject filtera) it filters to finding aids with that subjectb) The collecting areas listed are only those from the filtered finding aids

3) When a Collecting Area and a Subject are selecteda) it filters to only finding aids in the collecting area with that subjectb) the remaining Subjects are only those in the filtered findin aids