### PR TITLE
Skylight should ignore OKComputer requests

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,4 @@
+
+
+ignored_endpoints:
+  - OkComputer::OkComputerController#show


### PR DESCRIPTION
As per https://www.skylight.io/support/advanced-setup#ignoring-heartbeathealth-check-endpoints