### PR TITLE
#MAN-716 website finding aid creation issue

### DIFF
--- a/app/models/concerns/validators.rb
+++ b/app/models/concerns/validators.rb
@@ -47,4 +47,11 @@ module Validators
       end
     end
   end
+
+  class CollectionOrSubjectValidator < ActiveModel::Validator
+    def validate(record)
+      record.subject.reject! { |s| s.empty? }
+      record.errors[:base] << "Values for either Collections or Subjects need to be selected." if record.collections.blank? && record.subject.blank?
+    end
+  end
 end

--- a/app/models/finding_aid.rb
+++ b/app/models/finding_aid.rb
@@ -3,6 +3,7 @@
 class FindingAid < ApplicationRecord
   include InputCleaner
   include Categorizable
+  include Validators
 
   paginates_per 15
 
@@ -12,6 +13,7 @@ class FindingAid < ApplicationRecord
   has_paper_trail
 
   before_validation :sanitize_description
+  validates :collection_id, collection_or_subject: true
 
   serialize :subject
 

--- a/spec/factories/finding_aids.rb
+++ b/spec/factories/finding_aids.rb
@@ -4,10 +4,11 @@ FactoryBot.define do
   factory :finding_aid do
     name { "MyString" }
     description { "MyText" }
-    subject { ["MyString"] }
+    subject { ["history"] }
     content_link { "MyString" }
     identifier { "MyString" }
     drupal_id { "MyString" }
     path { "a-finding-aid" }
+    collections { [] }
   end
 end

--- a/spec/models/finding_aid_spec.rb
+++ b/spec/models/finding_aid_spec.rb
@@ -25,5 +25,26 @@ RSpec.describe FindingAid, type: :model do
     end
   end
 
+  describe "tests for collections and subjects" do
+    it "*has values in both fields*" do
+      finding_aid = FactoryBot.create(:finding_aid, collections: [FactoryBot.create(:collection)])
+      expect { finding_aid.save! }.not_to raise_error
+    end
+    it "has subject but no collection_id" do
+      finding_aid = FactoryBot.create(:finding_aid)
+      expect { finding_aid.save! }.not_to raise_error
+    end
+    it "has collection_id but no subject" do
+      finding_aid = FactoryBot.build(:finding_aid, collections: [FactoryBot.create(:collection)], subject: [""])
+      expect { finding_aid.save! }.not_to raise_error(/Values for either Collections or Subjects need to be selected./)
+    end
+    it "has neither subject nor collection_id" do
+      finding_aid = FactoryBot.build(:finding_aid, subject: [""])
+      expect { finding_aid.save! }.to raise_error(/Values for either Collections or Subjects need to be selected./)
+    end
+  end
+
+
+
   it_behaves_like "categorizable"
 end


### PR DESCRIPTION
Can we require that something have either a subject or a collection? That way, they are still browsable in the finding aids index page?
**************
Added custom validation for either/or condition.