### PR TITLE
#MAN-607 Databases link on homepage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,7 @@ class ApplicationController < ActionController::Base
     @org_charts = ExternalLink.find_by_slug("org-charts")
     @staff_forms = ExternalLink.find_by_slug("staff-forms")
     @chat_link = ExternalLink.find_by_slug("chat-link")
+    @db_az_link = ExternalLink.find_by_slug("db-az")
   end
 
   def show_hours

--- a/app/views/application/_header-search.html.erb
+++ b/app/views/application/_header-search.html.erb
@@ -7,6 +7,6 @@
 	<ul class="text-left">
 	  <li><%= link_to t("manifold.header.search.books"), "#{librarysearch_url("books")}" %></li>
     <li><%= link_to t("manifold.header.search.articles"), "#{librarysearch_url("articles")}" %></li>
-    <li><%= link_to t("manifold.header.search.databases"), "#{librarysearch_url("databases")}" %></li>
+    <li><%= link_to t("manifold.header.search.databases"), @db_az_link %></li>
 	</ul>
 </div>

--- a/app/views/application/_mobile-search.html.erb
+++ b/app/views/application/_mobile-search.html.erb
@@ -10,7 +10,7 @@
       <ul class="text-center">
         <li><%= link_to t("manifold.header.search.books"), "#{librarysearch_url("books")}" %></li>
         <li><%= link_to t("manifold.header.search.articles"), "#{librarysearch_url("articles")}" %></li>
-        <li><%= link_to t("manifold.header.search.databases"), "#{librarysearch_url("databases")}" %></li>
+        <li><%= link_to t("manifold.header.search.databases"), @db_az_link %></li>
       </ul>
     </div>
   </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -62,7 +62,7 @@
 			    <% end %>
 				</div>
 				<div class="h-22 square">
-			    <%= link_to "#{librarysearch_url}/databases" do %>
+			    <%= link_to @db_az_link do %>
 			      <%= image_tag('database_white.png', class: "icon decorative") %> <span>Databases</span>
 			    <% end %>
 				</div>


### PR DESCRIPTION
Please update the “Databases” link/button on the homepage to direct to the Springshare A-Z list https://guides.temple.edu/az.php instead of the databases search in library search.
*************
Created external link (in all environments) for the application controller.
Updated home page and header partials to use external link with slug: db-az