### PR TITLE
Add weighting to items in categories

### DIFF
--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -26,7 +26,7 @@ class BuildingsController < ApplicationController
   def navigation_items
     @nav_items = []
     @categories.each do |cat|
-      cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |item|
+      cat.items(exclude: [:category]).each do |item|
         unless item.id == @building.id
           @nav_items << item
         end

--- a/app/controllers/concerns/has_categories.rb
+++ b/app/controllers/concerns/has_categories.rb
@@ -5,7 +5,7 @@ module HasCategories
 
   def cat_link(cat, dog)
     links = []
-    cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |c|
+    cat.items(exclude: [:category]).each do |c|
       unless c == dog
         link = "<li>"
       else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -135,15 +135,15 @@ class PagesController < ApplicationController
   def scrc
     @scrc_location = Space.find_by_slug("scrc-room")
     @reading_room = Space.find_by_slug("scrc-reading-room")
-    @visit_links = Category.find_by_slug("scrc-study").items.sort_by { |e| e.label }
-    @collection_links = Category.find_by_slug("scrc-collections").items.sort_by { |e| e.label }
+    @visit_links = Category.find_by_slug("scrc-study").items
+    @collection_links = Category.find_by_slug("scrc-collections").items
     @page = Page.find_by_slug("scrc-intro")
   end
 
   def blockson
     @page = Page.find_by_slug("blockson-intro")
-    @visit_links = Category.find_by_slug("blockson-study").items.sort_by { |e| e.label }
-    @research_links = Category.find_by_slug("blockson-research").items.sort_by { |e| e.label }
+    @visit_links = Category.find_by_slug("blockson-study").items
+    @research_links = Category.find_by_slug("blockson-research").items
     @events = Event.where(["tags LIKE ? and end_time >= ?", "blockson", Time.now]).order(:start_time).take(4)
     @building = Building.find_by_slug("blockson")
   end
@@ -154,11 +154,11 @@ class PagesController < ApplicationController
     @innovation_location = Space.find_by_slug("innovation-sandbox")
     visit_links = Category.find_by_slug("lcdss-study")
     unless visit_links.nil?
-      @visit_links = visit_links.items.sort_by { |e| e.label }
+      @visit_links = visit_links.items
     end
     research_links = Category.find_by_slug("lcdss-research")
     unless research_links.nil?
-      @research_links = research_links.items.sort_by { |e| e.label }
+      @research_links = research_links.items
     end
     @event_links = Event.where(["tags LIKE ? and end_time >= ?", "%Digital Scholarship%", Time.now]).order(:start_time).take(5)
     @blog = Blog.find_by_slug("lcdss-blog")
@@ -170,9 +170,9 @@ class PagesController < ApplicationController
   def hsl
     @ginsburg_location = Building.find_by_slug("ginsburg")
     @podiatry_location = Building.find_by_slug("podiatry")
-    @visit_links = Category.find_by_slug("hsl-study").items.sort_by { |e| e.label }
-    @resource_links = Category.find_by_slug("hsl-resources").items.sort_by { |e| e.label }
-    @research_links = Category.find_by_slug("hsl-research").items.sort_by { |e| e.label }
+    @visit_links = Category.find_by_slug("hsl-study").items
+    @resource_links = Category.find_by_slug("hsl-resources").items
+    @research_links = Category.find_by_slug("hsl-research").items
     @event_links = Event.where(["tags LIKE ? and end_time >= ?", "%Health Science%", Time.now]).order(:start_time).take(5)
   end
 
@@ -211,7 +211,7 @@ class PagesController < ApplicationController
   def navigation_items
     @nav_items = []
     @page.categories.each do |cat|
-      cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |item|
+      cat.items(exclude: [:category]).each do |item|
         unless item.id == @page.id
           @nav_items << item
         end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -25,7 +25,7 @@ class PoliciesController < ApplicationController
   def navigation_items
     @nav_items = []
     @policy.categories.each do |cat|
-      cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |item|
+      cat.items(exclude: [:category]).each do |item|
         unless item.id == @policy.id
           @nav_items << item
         end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -29,7 +29,7 @@ class ServicesController < ApplicationController
   def navigation_items
     @nav_items = []
     @categories.each do |cat|
-      cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |item|
+      cat.items(exclude: [:category]).each do |item|
         unless item.id == @service.id
           @nav_items << item
         end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -27,7 +27,7 @@ class SpacesController < ApplicationController
   def navigation_items
     @nav_items = []
     @space.categories.each do |cat|
-      cat.items(exclude: [:category]).sort_by { |e| e.label }.each do |item|
+      cat.items(exclude: [:category]).each do |item|
         unless item.id == @space.id
           @nav_items << item
         end

--- a/app/dashboards/category_dashboard.rb
+++ b/app/dashboards/category_dashboard.rb
@@ -28,7 +28,6 @@ class CategoryDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    #:categorizations,
     :name,
     :id,
     :description,
@@ -68,5 +67,9 @@ class CategoryDashboard < Administrate::BaseDashboard
 
   def tinymce?
     true
+  end
+
+  def permitted_attributes
+    super + [categorizations_attributes: [:weight, :id]]
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,6 +8,14 @@ class ApplicationRecord < ActiveRecord::Base
     @today.to_date.strftime("%^A, %^B %d, %Y ")
   end
 
+  def category_weight
+    @weight
+  end
+
+  def category_weight=(weight)
+    @weight = weight
+  end
+
   def label
     respond_to?(label_method) ? self[label_method] : "#{self.class.to_s}_#{id}"
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def category_weight
-    @weight
+    @weight || 10
   end
 
   def category_weight=(weight)

--- a/app/models/categorization.rb
+++ b/app/models/categorization.rb
@@ -3,4 +3,6 @@
 class Categorization < ApplicationRecord
   belongs_to :categorizable, polymorphic: true
   belongs_to :category
+
+  validates :weight, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,6 +6,7 @@ class Category < ApplicationRecord
   include Imageable
 
   has_many :categorizations, dependent: :destroy
+  accepts_nested_attributes_for :categorizations
 
   has_many :nested_categorizations, as: :categorizable, dependent: :destroy, class_name: "Categorization"
   has_many :categories, through: :nested_categorizations
@@ -36,7 +37,7 @@ class Category < ApplicationRecord
       type.constantize.find(ids)
         .each_with_index { |obj, index| obj.category_weight = weights[index]  }
     end.reduce([], :concat)
-      .sort_by { |categorized| categorized&.category_weight || 10 }
+      .sort_by { |categorized| categorized&.category_weight }
   end
 
 
@@ -53,13 +54,4 @@ class Category < ApplicationRecord
   def path
     url(only_path: true)
   end
-
-  private
-    def categorizations_ordered_ids(categorizations)
-      categorizations.map { |categorization| global_categorizable_id(categorization) }
-    end
-
-    def global_categorizable_id(categorization)
-      "#{categorization.categorizable_type}_#{categorization.categorizable_id}"
-    end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -21,6 +21,7 @@ class Category < ApplicationRecord
   # eg @category.items(limit_to: [:events]) would
   def items(limit_to: [], exclude: [])
     grouped = categorizations.group_by(&:categorizable_type)
+
     if limit_to.present?
       grouped.select! { |ct, _ | limit_to.include?(ct.underscore.to_sym)  }
     end
@@ -31,13 +32,13 @@ class Category < ApplicationRecord
 
     grouped.map do |type, objs|
       ids = objs.map(&:categorizable_id)
+      weights = objs.map(&:weight)
       type.constantize.find(ids)
+        .each_with_index { |obj, index| obj.category_weight = weights[index]  }
     end.reduce([], :concat)
+      .sort_by { |categorized| categorized&.category_weight || 10 }
   end
 
-  def child_categories
-    items(limit_to: [:category])
-  end
 
   def url(only_path: false)
     if custom_url.present?
@@ -52,4 +53,13 @@ class Category < ApplicationRecord
   def path
     url(only_path: true)
   end
+
+  private
+    def categorizations_ordered_ids(categorizations)
+      categorizations.map { |categorization| global_categorizable_id(categorization) }
+    end
+
+    def global_categorizable_id(categorization)
+      "#{categorization.categorizable_type}_#{categorization.categorizable_id}"
+    end
 end

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -37,8 +37,17 @@ and renders all form fields for a resource's editable attributes.
     <% end -%>
   <% end -%>
 
-
+  <hr />
+  <div style="width:100%;">
+    <p>On the list of entities below, please assign a weight to
+      each entity. The weight will determine the order from lowest
+      to highest. For example, the item with a weight of one will
+      appear first in the list, a weight of one will appear next,
+      and so on.
+    </p>
+  </div>
   <div class="field-unit field-unit--categorizations" style="align-items:baseline;" >
+
     <div class="field-unit__label">
       <label>Entity Weights</label>
     </div>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -61,7 +61,7 @@ and renders all form fields for a resource's editable attributes.
             <%= categorizations_form.label categorizations_form.object.categorizable.label %>
           </span>
           <span style="display:inline-block;width:8%">
-            <%= categorizations_form.number_field(:weight, in: (1..10).reverse_each ) %>
+            <%= categorizations_form.number_field(:weight, {required: 'required', in: (1..10).reverse_each} ) %>
           </span>
         </div>
         <% end -%>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -4,7 +4,7 @@ This partial is rendered on a resource's `new` and `edit` pages,
 and renders all form fields for a resource's editable attributes.
 ## Local variables:
 - `page`:
-  An instance of [Administrate::Page::Form][1].
+  An instance of [Administrate::Page::Form][1]
   Contains helper methods to display a form,
   and knows which attributes should be displayed in the resource's form.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
@@ -36,6 +36,28 @@ and renders all form fields for a resource's editable attributes.
       </div>
     <% end -%>
   <% end -%>
+
+
+  <div class="field-unit field-unit--categorizations" style="align-items:baseline;" >
+    <div class="field-unit__label">
+      <label>Entity Weights</label>
+    </div>
+      <div class="field-unit__field" style="width:75%;">
+        <%= f.fields_for :categorizations, page.resource.categorizations.sort_by(&:weight) do |categorizations_form| %>
+        <div style="padding: 1.1em;border-bottom: 1px solid;">
+          <span style="width:20%;display:inline-block;">
+            <strong><%= categorizations_form.object.categorizable_type %></strong>
+          </span>
+          <span style="width:40%;display:inline-block">
+            <%= categorizations_form.label categorizations_form.object.categorizable.label %>
+          </span>
+          <span style="display:inline-block;width:8%">
+            <%= categorizations_form.number_field(:weight, in: (1..10).reverse_each ) %>
+          </span>
+        </div>
+        <% end -%>
+      </div>
+	</div>
 
   <div class="form-actions">
     <%= f.submit %>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -1,0 +1,48 @@
+<%#
+# Form Partial
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+## Local variables:
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes.each do |attribute| -%>
+    <% if user_editable_field?(current_account, attribute) %>
+      <div class="field-unit field-unit--<%= attribute.html_class %> <%= required?(attribute) %>" >
+        <%= render_field attribute, f: f %>
+      </div>
+    <% end -%>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>
+
+<% if @dashboard&.tinymce? %>
+  <%= tinymce_assets %>
+  <%= tinymce %>
+<% end %>

--- a/app/views/admin/categories/show.html.erb
+++ b/app/views/admin/categories/show.html.erb
@@ -54,6 +54,7 @@ as well as a link to its edit page.
           <tr>
             <th>Label</th>
             <th>Class</th>
+            <th>Weight</th>
             <th>Link</th>
           </tr>
         </thead>
@@ -62,6 +63,7 @@ as well as a link to its edit page.
             <%= tag.tr do %>
               <%= tag.td(item.label, class: "item-label") %>
               <%= tag.td(item.class, class: "item-class") %>
+              <%= tag.td(item.category_weight, class: "item-category-weight") %>
               <%= tag.td(link_to("Show", ["admin", item], class: "button")) %>
             <% end %>
           <% end %>

--- a/app/views/fields/description_field/_show.html.erb
+++ b/app/views/fields/description_field/_show.html.erb
@@ -1,1 +1,1 @@
-<%= field.data.html_safe %>
+<%= field.data&.html_safe %>

--- a/app/views/pages/_items.html.erb
+++ b/app/views/pages/_items.html.erb
@@ -1,6 +1,6 @@
 <% @page.categories.each do |cat| %>
   <div class="leftside-index">
-    
+
     <% unless @page.categories.size > 1 %>
       <div class="index-category">
     <% else %>
@@ -12,7 +12,7 @@
       <div class="index-items">
         <div>
           <ul class="list-unstyled">
-          <% cat.items(exclude: [:category]).sort_by{|e| e.label}.each do |c| %>
+          <% cat.items(exclude: [:category]).each do |c| %>
             <li <% if c == @page %> class="selected" <%end%>>
               <%= link_to c.label, url_for(c) %>
             </li>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: <%= ENV.fetch("MANIFOLD_DB_HOST") { "localhost" } %>
+  host: <%= ENV.fetch("MANIFOLD_DB_HOST") { "127.0.0.1" } %>
   pool: 5
   username: <%= ENV.fetch("MANIFOLD_DB_USER") { "manifold" } %>
   password: <%= ENV.fetch("MANIFOLD_DB_PASSWORD") { "password" }%>

--- a/db/migrate/20191007172619_add_weight_to_categorizations.rb
+++ b/db/migrate/20191007172619_add_weight_to_categorizations.rb
@@ -2,6 +2,6 @@
 
 class AddWeightToCategorizations < ActiveRecord::Migration[5.2]
   def change
-    add_column :categorizations, :weight, :integer
+    add_column :categorizations, :weight, :integer, default: 10
   end
 end

--- a/db/migrate/20191007172619_add_weight_to_categorizations.rb
+++ b/db/migrate/20191007172619_add_weight_to_categorizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeightToCategorizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categorizations, :weight, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -333,6 +333,7 @@ ActiveRecord::Schema.define(version: 2019_10_09_153513) do
     t.string "personal_site"
     t.string "springshare_id"
     t.string "specialties"
+    t.string "libguides_account"
   end
 
   create_table "policies", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2019_10_09_153513) do
     t.integer "categorizable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "weight"
     t.index ["category_id", "categorizable_id", "categorizable_type"], name: "polymorphic_categorizations", unique: true
     t.index ["category_id"], name: "index_categorizations_on_category_id"
   end
@@ -332,7 +333,6 @@ ActiveRecord::Schema.define(version: 2019_10_09_153513) do
     t.string "personal_site"
     t.string "springshare_id"
     t.string "specialties"
-    t.string "libguides_account"
   end
 
   create_table "policies", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -128,7 +128,7 @@ ActiveRecord::Schema.define(version: 2019_10_09_153513) do
     t.integer "categorizable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "weight"
+    t.integer "weight", default: 10
     t.index ["category_id", "categorizable_id", "categorizable_type"], name: "polymorphic_categorizations", unique: true
     t.index ["category_id"], name: "index_categorizations_on_category_id"
   end
@@ -333,7 +333,6 @@ ActiveRecord::Schema.define(version: 2019_10_09_153513) do
     t.string "personal_site"
     t.string "springshare_id"
     t.string "specialties"
-    t.string "libguides_account"
   end
 
   create_table "policies", force: :cascade do |t|

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -201,6 +201,37 @@ end
       end
     end
 
+    context "when items in a category are weighted" do
+      before do
+        building.categories << category
+        building.categorizations.first.update_attribute("weight", 3)
+        building2.categories << category
+        building2.categorizations.first.update_attribute("weight", 1)
+        event.categories << category
+        event.categorizations.first.update_attribute("weight", 2)
+      end
+
+      it "returns items in the expected order" do
+        expect(category.items).to eql [building2, event, building]
+      end
+    end
+
+    context "when some items in a category are weighted and some are not" do
+      before do
+        building.categories << category
+        building.categorizations.first.update_attribute("weight", 2)
+
+        building2.categories << category
+
+        event.categories << category
+        event.categorizations.first.update_attribute("weight", 1)
+      end
+
+      it "weighted items sort first, in expected order, followed by unweighted items" do
+        expect(category.items).to eql [event, building, building2]
+      end
+    end
+
     context "deleting an categorized item" do
       before do
         building.categories << category
@@ -212,23 +243,6 @@ end
         expect(category.items).not_to include(old_building)
       end
     end
-    context "child_categories" do
-
-       context "when the category has child categories" do
-         it "returns an array of those categories, but not other" do
-           building.categories << parent_category
-           category.categories << parent_category
-           expect(parent_category.child_categories).to include(category)
-           expect(parent_category.child_categories).not_to include(building)
-         end
-       end
-       context "when it has no child categories" do
-         it "returns an empty array" do
-           building.categories << parent_category
-           expect(parent_category.child_categories).to eql([])
-         end
-       end
-     end
   end
 
   context "#categories" do


### PR DESCRIPTION
Items in Categories can now be weighted from 1-10, with 1 being most important, 10 being the least (and the default).

Category Item weightings can be assigned in the Admin Category Edit page.

Weighting will affect order in navigation menus, and order in multiple pages where a categories are used to list the items on a page, like the HSL home page research links, visit links, etc.

This also removes the default alphabetical sort that was in place in those pages. 