### PR TITLE
Replace non existent hours path helper

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -38,10 +38,10 @@ SitemapGenerator::Sitemap.create do
   add "/scrc"
   add "/lcdss"
   add "/"
+  add "/hours"
 
   #indices
   add forms_path
-  add library_hours_path
   add people_path
   add events_path
 


### PR DESCRIPTION
`rake sitemap:create` currently fails with

```
In '/Users/cbn/projects/manifold/public/':
rake aborted!
NameError: undefined local variable or method `library_hours_path' for #<SitemapGenerator::Interpreter:0x00007fae58d2b640>
/Users/cbn/projects/manifold/config/sitemap.rb:44:in `block in run'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/interpreter.rb:61:in `instance_eval'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/interpreter.rb:61:in `eval'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/link_set.rb:40:in `create'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator.rb:41:in `method_missing'
/Users/cbn/projects/manifold/config/sitemap.rb:6:in `run'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/interpreter.rb:78:in `instance_eval'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/interpreter.rb:78:in `run'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/sitemap_generator-6.0.2/lib/sitemap_generator/tasks.rb:51:in `block (2 levels) in <top (required)>'
/Users/cbn/.rvm/gems/ruby-2.5.1/gems/rake-13.0.0/exe/rake:27:in `<top (required)>'
/Users/cbn/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `eval'
/Users/cbn/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => sitemap:create
(See full trace by running task with --trace)
````