### PR TITLE
#MAN-721 Change link on "Explore Charles Library" on homepage

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -132,6 +132,7 @@ class PagesController < ApplicationController
     @locations = Building.find_by_slug("ambler")
     @todays_hours = LibraryHour.find_by(location_id: "charles", date: @today)
     @libguides = ExternalLink.find_by_slug("libguides")
+    @explore_charles = Page.find_by_slug("explore-charles")
   end
 
   def scrc

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -39,7 +39,7 @@
 	  </div>
 	  <div class="col-12 col-lg-3">
 	    <div class="cta-white">
-		    <%= link_to pages_charles_path, class: "strong" do %>
+		    <%= link_to @explore_charles, class: "strong" do %>
 		      <%= image_tag('explore_charles.png', class: "decorative") %> <span>Explore Charles Library</span>
 	      <% end %>
 	    </div>


### PR DESCRIPTION
On the homepage, please update the link that goes out from "Explore Charles Library" to be https://library.temple.edu/pages/49
**************
"explore-charles" slug added to PAGE: 49 on production; PAGE: 41 on qa (since page 49 does not yet exist on qa).

Marketing page perviously linked still available at: /explore-charles