### PR TITLE
#MAN-727 Copy fix on events

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -21,7 +21,7 @@
         <%= link_to @mailing_list do %>
         <h2>
           <%= image_tag "email.png", class: "category-icon decorative"  %>
-          <br />Sign Up for our mailing list
+          <br />Sign up for our mailing list
         </h2>
         <% end %>
       </div>


### PR DESCRIPTION
The sign up link on /events says "Sign Up for our mailing list" with a
capital U but it should be a lowercase u.