### PR TITLE
#MAN-709 Updates to Alert Entity Fields

### DIFF
--- a/app/controllers/admin/alerts_controller.rb
+++ b/app/controllers/admin/alerts_controller.rb
@@ -3,11 +3,12 @@
 module Admin
   class AlertsController < Admin::ApplicationController
     load_and_authorize_resource
-    include Admin::SortByAttribute
 
-    # Override the default sort of id
-    def sort_by
-      :scroll_text
+    def order
+      @order ||= Administrate::Order.new(
+        params.fetch(resource_name, {}).fetch(:order, "published"),
+        params.fetch(resource_name, {}).fetch(:direction, "desc"),
+      )
     end
 
     # Devise has current_user hard_coded so if we us anything other than

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,27 +2,19 @@
 
 module Admin
   class EventsController < Admin::ApplicationController
-    include Admin::SortByAttribute
     include Admin::Detachable
-    # Override the default sort of id
-    def sort_by
-      :start_time
+
+    def order
+      @order ||= Administrate::Order.new(
+        params.fetch(resource_name, {}).fetch(:order, "start_time"),
+        params.fetch(resource_name, {}).fetch(:direction, "desc"),
+      )
     end
 
     def sync
       SyncService::Events.call()
       flash[:notice] = "Events synced"
       redirect_to admin_events_path
-    end
-
-  private
-
-    # Workaround that prevents updating event objects
-    def default_params
-      resource_params = params.fetch(resource_name, {})
-      order = resource_params.fetch(:order, "start_time")
-      direction = resource_params.fetch(:direction, "asc")
-      params[resource_name] = resource_params.merge(order: order, direction: direction)
     end
   end
 end


### PR DESCRIPTION
Updates default sort order method due to inability to reorder sort, or update alerts.

Also applied to events admin controller for consistency and more concise code.