### PR TITLE
Sync based on guid, add verbose logging, force option for event sync

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -2,27 +2,19 @@
 
 module Admin
   class EventsController < Admin::ApplicationController
-    include Admin::SortByAttribute
     include Admin::Detachable
-    # Override the default sort of id
-    def sort_by
-      :start_time
+
+    def order
+      @order ||= Administrate::Order.new(
+        params.fetch(resource_name, {}).fetch(:order, "start_time"),
+        params.fetch(resource_name, {}).fetch(:direction, "desc"),
+      )
     end
 
     def sync
-      SyncService::Events.call()
+      SyncService::Events.call(force: true)
       flash[:notice] = "Events synced"
       redirect_to admin_events_path
-    end
-
-  private
-
-    # Workaround that prevents updating event objects
-    def default_params
-      resource_params = params.fetch(resource_name, {})
-      order = resource_params.fetch(:order, "start_time")
-      direction = resource_params.fetch(:direction, "asc")
-      params[resource_name] = resource_params.merge(order: order, direction: direction)
     end
   end
 end

--- a/app/dashboards/event_dashboard.rb
+++ b/app/dashboards/event_dashboard.rb
@@ -38,6 +38,7 @@ class EventDashboard < BaseDashboard
     alt_text: Field::String,
     ensemble_identifier: Field::String,
     categories: Field::HasMany,
+    guid: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -84,6 +85,7 @@ class EventDashboard < BaseDashboard
     :registration_link,
     :content_hash,
     :ensemble_identifier,
+    :guid,
     :categories,
     :created_at,
     :updated_at,
@@ -119,6 +121,7 @@ class EventDashboard < BaseDashboard
     :registration_link,
     :content_hash,
     :ensemble_identifier,
+    :guid,
     :categories
   ].freeze
 

--- a/db/migrate/20191016125318_add_guid_to_events.rb
+++ b/db/migrate/20191016125318_add_guid_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGuidToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :guid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_195537) do
+ActiveRecord::Schema.define(version: 2019_10_16_125318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 2019_10_11_195537) do
     t.boolean "all_day", default: false
     t.string "event_type"
     t.string "slug"
+    t.string "guid"
     t.index ["building_id"], name: "index_events_on_building_id"
     t.index ["person_id"], name: "index_events_on_person_id"
     t.index ["space_id"], name: "index_events_on_space_id"

--- a/lib/tasks/events_sync.rake
+++ b/lib/tasks/events_sync.rake
@@ -4,6 +4,7 @@ namespace :sync do
   desc "sync events"
   task :events, [:path] => :environment do |t, args|
     args.with_defaults(path: nil)
-    SyncService::Events.call(events_url: args[:path])
+    force = ENV.fetch("FORCE_SYNC", false)
+    SyncService::Events.call(events_url: args[:path], force: force)
   end
 end

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -42,4 +42,19 @@ RSpec.describe Admin::EventsController, type: :controller do
       expect(response.body).to match(original_title)
     end
   end
+
+  describe "GET #sync" do
+    let (:event) { FactoryBot.create(:event) }
+    before do
+      sign_in(@account)
+      # Stub out the sync service so we don't actually make
+      # http requests for XML. We jut want to test that
+      # we are calling the service integration correctly
+      allow(::SyncService::Events).to receive(:call)
+    end
+    it "renders edit form" do
+      post :sync
+      expect(::SyncService::Events).to have_received(:call).with(force: true)
+    end
+  end
 end

--- a/spec/fixtures/files/badimage-event.xml
+++ b/spec/fixtures/files/badimage-event.xml
@@ -29,7 +29,7 @@
     <ContactName>Gretchen Sneff</ContactName>
     <ContactEmail>gsneff@temple.edu</ContactEmail>
     <ContactPhone>215-204-4724</ContactPhone>
-    <Image>&lt;img typeof="foaf:Image" src="https://exampe.com/noimage.jpg" alt="data" /&gt;</Image>
+    <Image>&lt;img typeof="foaf:Image" src="https://example.com/noimage.jpg" alt="data" /&gt;</Image>
     <Files></Files>
     <GAFFunding>0</GAFFunding>
     <Private>0</Private>

--- a/spec/fixtures/files/events-onebad.xml
+++ b/spec/fixtures/files/events-onebad.xml
@@ -29,7 +29,7 @@
     <ContactName>Gretchen Sneff</ContactName>
     <ContactEmail>gsneff@temple.edu</ContactEmail>
     <ContactPhone>215-204-4724</ContactPhone>
-    <Image>&lt;img typeof="foaf:Image" src="https://exampe.com/noimage.jpg" alt="data" /&gt;</Image>
+    <Image>&lt;img typeof="foaf:Image" src="https://example.com/noimage.jpg" alt="data" /&gt;</Image>
     <Files></Files>
     <GAFFunding>0</GAFFunding>
     <Private>0</Private>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,11 +75,15 @@ RSpec.configure do |config|
 
 
   config.before(:each) do
-    stub_request(:get, /.*events\.temple\.edu\/.*\.jpg.*/)
+    stub_request(:get, /.*events\.temple\.edu\/.*\.jpg.*/im)
       .to_return(
         status: 200,
         body: File.open("#{fixture_path}/charles.jpg"), headers: {}
       )
+
+    stub_request(:get, "https://example.com/noimage.jpg").
+      to_return(status: 403, body: "Nope", headers: {})
+
 
     stub_request(:get, "https://sites.temple.edu/devopsing/feed").
     to_return(status: 200, body: File.open("#{fixture_path}/blog_posts.rss") , headers: {})

--- a/spec/services/sync_events_spec.rb
+++ b/spec/services/sync_events_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe SyncService::Events, type: :service do
     describe "maps events xml to db schema" do
       subject { @sync_events.record_hash(@events.first) }
 
+      it "maps GUID to guid field" do
+        expect(subject["guid"]).to match(@events.first["GUID"])
+      end
+
       it "maps Title to title field" do
         expect(subject["title"]).to match(@events.first["Title"])
       end
@@ -207,7 +211,7 @@ RSpec.describe SyncService::Events, type: :service do
     let(:sync_event) { described_class.new(events_url: file_fixture("single_event.xml").to_path) }
     let(:force_sync_event) { described_class.new(events_url: file_fixture("single_event.xml").to_path, force: true) }
 
-    it "does not update the record" do
+    it "updates the record" do
       sync_event.sync
       first_time = Event.find_by(title: "BLAH BLAH Foo foo").updated_at
       force_sync_event.sync
@@ -218,7 +222,7 @@ RSpec.describe SyncService::Events, type: :service do
 
   end
 
-  context "all day event", :skip do
+  context "all day event" do
     let(:sync_event) { described_class.new(events_url: file_fixture("single_event.xml").to_path) }
     subject { @sync_events.record_hash(@events.last) }
 


### PR DESCRIPTION
Adds much more granular logging of event sync jobs.

Adds a force option, which causes all events in the feed to overwrite
existing events, not skipping when a matching hash is found. Useful when
code changes are made to the events sync that would not be picked up
because of the content_hash match.

The sync button in the Events dashboard now uses the force sync, so this
can be used manually after deploys the alter this code.

Testing
-------
You should test that:

- Existing Events without a GUID (you can see it in an admin event show page) that appear in the current feed are re-saved with a GUID when running the sync from the Events dashboard.
- When running a sync, no duplicate events are created.