### PR TITLE
#MAN-700 Recreate WPVI videos page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,9 @@ class PagesController < ApplicationController
   before_action :navigation_items, only: [:show, :charles]
   before_action :video_init, only: [:videos_all, :videos_show, :videos_list, :videos_search]
 
+  def wpvi
+  end
+
 
   def get_highlights
     @highlights = Highlight.where(promoted: true).take(4)

--- a/app/views/pages/wpvi.html.erb
+++ b/app/views/pages/wpvi.html.erb
@@ -1,0 +1,18 @@
+<div class="container">
+	<div class="row" style="margin-top: 21px;">
+	<div class="col">
+		<h1> WPVI News Footage Collection</h1>
+		<ul>
+			<li>This video collection is only accessible in the Special Collections Research Center's reading room, in the Paley Library.</li>
+			<li>For more information about this collection please see the finding aid (Series 2, Accession B)</li>
+			<li>When searching the collection, do not use truncation/wildcard symbol (*) or quotation marks ("")</li>
+			<li><strong style="font-size: larger">And please be patient. Due to the large number of files, searching and loading will be gradual.</strong></li>
+		</ul>
+	</div>
+</div>
+<div class="row">
+	<div class="col text-center">
+		<iframe id="ensembleFrame_jU380Gd-j0yJuJiR3hWlgQ" src="https://ensemble.temple.edu/app/plugin/embed.aspx?DestinationID=jU380Gd-j0yJuJiR3hWlgQ&playlistEmbed=true&isNewPluginEmbed=true&displayTitle=true&orderBy=videoTitle&orderByDirection=asc&displayEmbedCode=false&displayAttachments=false&displayAnnotations=false&displayLinks=false&displayCredits=false&displayDateProduced=false&displayCaptionSearch=false" frameborder="0" style="width: 800px; height : 1000px;" height="1000" width="800" allowfullscreen></iframe>
+	</div>
+</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
     get "home" => :home, as: "pages_home"
     get "lcdss" => :tudsc, as: "pages_lcdss"
     get "explore-charles" => :charles, as: "pages_charles"
+    get "wpvi" => :wpvi
     get "watchpastprograms" => :videos_all, as: "pages_videos_all"
     get "watchpastprograms/list/:collection" => :videos_list, as: "pages_videos_collection"
     get "watchpastprograms/search" => :videos_search, as: "pages_videos_search"


### PR DESCRIPTION
Redoes the Ensemble streaming for WPVI to use the native Ensemble embedded playlist now that it does not have ADA outstanding concerns.

Access will be restricted by IP to three machines in the scrc reading room.

For testing, let me know your IP and I'll set it up temporarily for testing.