### PR TITLE
Add secondary alpha sort to category items

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -37,7 +37,7 @@ class Category < ApplicationRecord
       type.constantize.find(ids)
         .each_with_index { |obj, index| obj.category_weight = weights[index]  }
     end.reduce([], :concat)
-      .sort_by { |categorized| categorized&.category_weight }
+      .sort_by { |categorized| [categorized&.category_weight, categorized&.label] }
   end
 
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -251,6 +251,17 @@ end
       end
     end
 
+    context "when no items are weighted" do
+      before do
+        building.categories << category
+        building2.categories << category
+        event.categories << category
+      end
+      it "sorts them alphabetically by label" do
+        expect(category.items).to eql [building, building2, event]
+      end
+    end
+
     context "deleting an categorized item" do
       before do
         building.categories << category


### PR DESCRIPTION
This way, equally weighted items will have a predicatable order.