### PR TITLE
MAN-738 Add structured data to buildings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,9 +19,6 @@ module ApplicationHelper
   end
 
   def json_ld(entity)
-    entity_hash = entity.to_ld
-
-    entity_rdf = JSON.parse entity_hash.to_json
-    raw(entity_rdf.to_json)
+    raw(entity.map_to_schema_dot_org.to_json)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,11 @@ module ApplicationHelper
       Rails.configuration.librarysearch_base_url + "/" + type
     end
   end
+
+  def json_ld(entity)
+    entity_hash = entity.to_ld
+
+    entity_rdf = JSON.parse entity_hash.to_json
+    raw(entity_rdf.to_json)
+  end
 end

--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -20,37 +20,6 @@ module EventHelper
     tags
   end
 
-  def json_ld(event)
-    event_hash = {}
-    event_hash["@context"] = "http://schema.org"
-    event_hash["@type"] = "Event"
-    event_hash["eventStatus"] = "http://schema.org/EventCancelled" if event["cancelled"]
-    event_hash["name"] = event[:title]
-    event_hash["description"] = strip_tags(event[:description])
-    unless event_hash["all_day"]
-      event_hash["startTime"] = event[:start_time] unless event[:start_time].nil?
-      event_hash["endTime"] = event[:end_time] unless event[:end_time].nil?
-    end
-
-    if event.building
-      event_hash["location"] ||= {}
-      event_hash["location"]["@type"] = "Place"
-      event_hash["location"]["name"] = event.building.name
-    elsif event.attributes.has_key?("external_building")
-      event_hash["location"] = {}
-      event_hash["location"]["@type"] = "Place"
-      event_hash["location"]["name"] = event[:external_building]
-      event_hash["location"]["address"] = {}
-      event_hash["location"]["address"]["@type"] = "PostalAddress"
-      event_hash["location"]["address"]["streetAddress"] = event[:external_address]
-      event_hash["location"]["address"]["addressLocality"] = event[:external_city]
-      event_hash["location"]["address"]["addressRegion"] = event[:external_state]
-      event_hash["location"]["address"]["postalCode"] = event[:external_zip]
-    end
-
-    event_rdf = JSON.parse event_hash.to_json
-    raw(event_rdf.to_json)
-  end
   def get_bldg_name(bldg_name)
     unless bldg_name.nil?
       t("manifold.default.event.#{bldg_name.parameterize.underscore}", default: bldg_name)

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,58 +1,53 @@
 # frozen_string_literal: true
 
 class Building < ApplicationRecord
-  has_paper_trail
-  include Validators
-  include InputCleaner
-  include HasPolicies
-  include SetDates
-  include Categorizable
-  include Imageable
-  include HasHours
   require "uploads"
 
+  include Categorizable
+  include HasHours
+  include HasPolicies
+  include Imageable
+  include InputCleaner
+  include SetDates
+  include SchemaDotOrgable
+  include Validators
+
+
+  before_validation :normalize_phone_number
+  before_validation :sanitize_description
   validates :name, :address1, :address2, :temple_building_code, :coordinates, :google_id, :campus, presence: true
   validates :phone_number, presence: true, phone_number: true
   validates :description, presence: true
 
+  belongs_to :external_link, optional: true
   has_many :library_hours
   has_many :spaces
-  belongs_to :external_link, optional: true
+  has_paper_trail
 
   auto_strip_attributes :email
-
-  before_validation :normalize_phone_number
-  before_validation :sanitize_description
 
   def street_address
     address1
   end
 
-  def locality
-    address2.match(/^(?<city>\w*)\, (?<state>\w{2})\W+(?<zip>\d*)$/)
+  def schema_dot_org_type
+    "Building"
   end
 
-  def to_ld
-    building_hash = {}
-    building_hash["@type"] = "Building"
-    building_hash["name"] = name
-    building_hash["description"] = ActionController::Base.helpers.strip_tags(description)
-
-    building_hash["location"] = {}
-    building_hash["location"]["@type"] = "Place"
-    building_hash["location"]["address"] = {}
-    building_hash["location"]["address"]["@type"] = "PostalAddress"
-    building_hash["location"]["address"]["streetAddress"] = address1
-    building_hash["location"]["address"]["addressLocality"] = locality[:city]
-    building_hash["location"]["address"]["addressRegion"] = locality[:state]
-    building_hash["location"]["address"]["postalCode"] = locality[:zip]
-
-    building_hash["telephone"] = phone_number
-    building_hash["email"] = email
-    building_hash["image"] = Rails.application.routes.url_helpers.rails_representation_url(show_image) if image.attached?
-    building_hash["containedInPlace"] = campus
-    building_hash["geo"] = coordinates
-    building_hash["googleId"] = google_id
-    building_hash
+  def additional_schema_dot_org_attributes
+    {
+      location: {
+        "@type" => "https://schema.org/Place",
+        address: {
+          "@type" => "https://schema.org/PostalAddress",
+          streetAddress: address1,
+          addressLocality: address2
+        }
+      },
+      telephone: phone_number,
+      email: email,
+      geo: coordinates,
+      googleId: google_id,
+    }
   end
 end

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -23,4 +23,36 @@ class Building < ApplicationRecord
 
   before_validation :normalize_phone_number
   before_validation :sanitize_description
+
+  def street_address
+    address1
+  end
+
+  def locality
+    address2.match(/^(?<city>\w*)\, (?<state>\w{2})\W+(?<zip>\d*)$/)
+  end
+
+  def to_ld
+    building_hash = {}
+    building_hash["@type"] = "Building"
+    building_hash["name"] = name
+    building_hash["description"] = ActionController::Base.helpers.strip_tags(description)
+
+    building_hash["location"] = {}
+    building_hash["location"]["@type"] = "Place"
+    building_hash["location"]["address"] = {}
+    building_hash["location"]["address"]["@type"] = "PostalAddress"
+    building_hash["location"]["address"]["streetAddress"] = address1
+    building_hash["location"]["address"]["addressLocality"] = locality[:city]
+    building_hash["location"]["address"]["addressRegion"] = locality[:state]
+    building_hash["location"]["address"]["postalCode"] = locality[:zip]
+
+    building_hash["telephone"] = phone_number
+    building_hash["email"] = email
+    building_hash["image"] = Rails.application.routes.url_helpers.rails_representation_url(show_image) if image.attached?
+    building_hash["containedInPlace"] = campus
+    building_hash["geo"] = coordinates
+    building_hash["googleId"] = google_id
+    building_hash
+  end
 end

--- a/app/models/concerns/imageable.rb
+++ b/app/models/concerns/imageable.rb
@@ -11,12 +11,36 @@ module Imageable
     custom_image(220, 220)
   end
 
+  def index_image_path
+    entity_image_path("medium")
+  end
+
+  def index_image_url
+    entity_image_url("medium")
+  end
+
   def thumb_image
     custom_image(120, 120)
   end
 
+  def thumb_image_path
+    entity_image_path("thumbnail")
+  end
+
+  def thumb_image_url
+    entity_image_url("thumbnail")
+  end
+
   def show_image
     custom_image(300, 300)
+  end
+
+  def show_image_path
+    entity_image_path("large")
+  end
+
+  def show_image_url
+    entity_image_url("large")
   end
 
   def custom_image(width, height)
@@ -30,5 +54,13 @@ module Imageable
 
   def image_variation(width, height)
     ActiveStorage::Variation.new(Uploads.resize_to_fill(width: width, height: height, blob: image.blob, gravity: "Center"))
+  end
+
+  def entity_image_path(type)
+    Rails.application.routes.url_helpers.send("#{self.class.to_s.underscore}_image_#{type}_path", id)
+  end
+
+  def entity_image_url(type)
+    Rails.application.routes.url_helpers.send("#{self.class.to_s.underscore}_image_#{type}_url", id)
   end
 end

--- a/app/models/concerns/schema_dot_orgable.rb
+++ b/app/models/concerns/schema_dot_orgable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SchemaDotOrgable
+  extend ActiveSupport::Concern
+
+
+  def base_attributes
+    {
+      "@context" => "https://schema.org",
+      "@type" => "#{schema_dot_org_type}",
+      name: label,
+      description: (ActionController::Base.helpers.strip_tags(description) if respond_to?(:description)),
+      image: (index_image_url if (respond_to?(:index_image_url) && image&.attached?)),
+    }.compact
+  end
+
+  def additional_schema_dot_org_attributes
+    {}
+  end
+
+  def merge_base_and_additional_attributes
+    base_attributes.merge(additional_schema_dot_org_attributes).compact.with_indifferent_access
+  end
+
+  def map_to_schema_dot_org
+    begin
+      merge_base_and_additional_attributes
+    rescue => exception
+      Honeybadger.notify(exception)
+      {}
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -57,4 +57,35 @@ class Event < ApplicationRecord
   def label
     title
   end
+
+  def to_ld
+    event_hash = {}
+    event_hash["@context"] = "http://schema.org"
+    event_hash["@type"] = "Event"
+    event_hash["eventStatus"] = "http://schema.org/EventCancelled" if cancelled
+    event_hash["name"] = title
+    event_hash["description"] = ActionController::Base.helpers.strip_tags(description)
+    unless event_hash["all_day"]
+      event_hash["startTime"] = start_time unless start_time.nil?
+      event_hash["endTime"] = end_time unless end_time.nil?
+    end
+
+    if building
+      event_hash["location"] ||= {}
+      event_hash["location"]["@type"] = "Place"
+      event_hash["location"]["name"] = building.name
+    elsif attributes.has_key?("external_building")
+      event_hash["location"] = {}
+      event_hash["location"]["@type"] = "Place"
+      event_hash["location"]["name"] = external_building
+      event_hash["location"]["address"] = {}
+      event_hash["location"]["address"]["@type"] = "PostalAddress"
+      event_hash["location"]["address"]["streetAddress"] = external_address
+      event_hash["location"]["address"]["addressLocality"] = external_city
+      event_hash["location"]["address"]["addressRegion"] = external_state
+      event_hash["location"]["address"]["postalCode"] = external_zip
+
+    end
+    event_hash
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,9 +2,10 @@
 
 class Event < ApplicationRecord
   has_paper_trail
-  include InputCleaner
   include Categorizable
   include Imageable
+  include InputCleaner
+  include SchemaDotOrgable
 
   paginates_per 5
   belongs_to :building, optional: true
@@ -22,12 +23,16 @@ class Event < ApplicationRecord
     self.event_type.split(",").collect(&:strip)
   end
 
-  def building_name(event)
-    if event.building
-      event.building.name
-    else
-      event.external_building
-    end
+  def building_name
+    building ? building.name : external_building
+  end
+
+  def building_address1
+    building ? building.address1 : external_address
+  end
+
+  def building_address2
+    building ? building.address2 : "#{external_city}, #{external_state} #{external_zip}"
   end
 
   def can_visit
@@ -58,34 +63,24 @@ class Event < ApplicationRecord
     title
   end
 
-  def to_ld
-    event_hash = {}
-    event_hash["@context"] = "http://schema.org"
-    event_hash["@type"] = "Event"
-    event_hash["eventStatus"] = "http://schema.org/EventCancelled" if cancelled
-    event_hash["name"] = title
-    event_hash["description"] = ActionController::Base.helpers.strip_tags(description)
-    unless event_hash["all_day"]
-      event_hash["startTime"] = start_time unless start_time.nil?
-      event_hash["endTime"] = end_time unless end_time.nil?
-    end
+  def schema_dot_org_type
+    "Event"
+  end
 
-    if building
-      event_hash["location"] ||= {}
-      event_hash["location"]["@type"] = "Place"
-      event_hash["location"]["name"] = building.name
-    elsif attributes.has_key?("external_building")
-      event_hash["location"] = {}
-      event_hash["location"]["@type"] = "Place"
-      event_hash["location"]["name"] = external_building
-      event_hash["location"]["address"] = {}
-      event_hash["location"]["address"]["@type"] = "PostalAddress"
-      event_hash["location"]["address"]["streetAddress"] = external_address
-      event_hash["location"]["address"]["addressLocality"] = external_city
-      event_hash["location"]["address"]["addressRegion"] = external_state
-      event_hash["location"]["address"]["postalCode"] = external_zip
-
-    end
-    event_hash
+  def additional_schema_dot_org_attributes
+    {
+      eventStatus: ("http://schema.org/EventCancelled" if cancelled),
+      startDate: start_time,
+      endDate: end_time,
+      location: {
+        "@type" => "Place",
+        name: building_name,
+        address: {
+          "@type" => "PostalAddress",
+          streetAddress: building_address1,
+          addressLocality: building_address2
+        }
+      }
+    }
   end
 end

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -1,3 +1,7 @@
+<script type="application/ld+json">
+  <%= json_ld(@building) %>
+</script>
+
 <%= render "mobile-menu-secondary" %>
 
 <div class="container">

--- a/docs/schema_dot_orgable.md
+++ b/docs/schema_dot_orgable.md
@@ -1,0 +1,26 @@
+# Adding schema.org metadata via the `SchemaDotOrgable` concern.
+
+The `SchemaDotOrgable` model concern allows you to define a mapping of your entity's data to schema.org attributes.
+
+## Required 
+When including `SchemaDotOrgable`, you *MUST* define a method `schema_dot_org_type` that returns a string of the schema.org type this will map to. For example, ActiveRecord entity event maps to https://schema.org/Event. The `schema_dot_org_type` should return `"Event"`.
+
+
+## Adding Additional Attributes
+You *MAY* also define addtional attributes by defining an `additional_schema_dot_org_attributes` method that returns a hash mapping schema.org types  to entity attributes or methods. For example, `{startDate: start_time}` maps the schema.org attribute `startDate` to the Event entity attribute `start_time`.
+
+## Conditional Attributes
+A common pattern for conditionally adding an attribute is to only set the value conditionally, like:
+```ruby
+image: (index_image_url if respond_to?(:index_image_url)),
+```
+SchemaDotOrgable compacts the hash before returning, so any keys with nil as the value will be removed.
+
+## Adding it to the View
+
+Once you ahve included `SchemaDotOrgable` into the model and defined your additional attributes, you need to add it to the show page for the entity, with a snippet like:
+```html
+<script type="application/ld+json">
+  <%= json_ld(@building) %>
+</script>
+```

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -55,53 +55,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  context "JSON-LD" do
-    describe "Common fields" do
-      let(:event) { FactoryBot.create(:event) }
-      subject { JSON.parse(json_ld(event)) }
+  context "json_ld" do
+    let(:entity) { OpenStruct.new(map_to_schema_dot_org: { one: 2 }) }
+    let(:ld) { json_ld(entity) }
 
-      it "has common values" do
-        expect(subject["@context"]).to eq "http://schema.org"
-        expect(subject["@type"]).to eq "Event"
-        expect(subject["name"]).to eq event[:title]
-        expect(subject["description"]).to eq event[:description]
-      end
-    end
-    describe "Location" do
-      example "campus building" do
-        building = FactoryBot.create(:building)
-        event = FactoryBot.create(:event, building: building)
-        input = JSON.parse(json_ld(event))
-        expect(input["location"]["@type"]).to eq "Place"
-        expect(input["location"]["name"]).to eq building.name
-      end
-
-      example "Location is external building" do
-        event = FactoryBot.create(:event)
-        input = JSON.parse(json_ld(event))
-        expect(input["location"]["@type"]).to eq "Place"
-        expect(input["location"]["name"]).to eq event[:external_building]
-        expect(input["location"]["address"]["@type"]).to eq "PostalAddress"
-        expect(input["location"]["address"]["streetAddress"]).to eq event[:external_address]
-        expect(input["location"]["address"]["addressRegion"]).to eq event[:external_state]
-        expect(input["location"]["address"]["postalCode"]).to eq event[:external_zip]
-      end
-    end
-
-    describe "timed event" do
-      example "start and end time" do
-        event = FactoryBot.create(:event)
-        input = JSON.parse(json_ld(event))
-        expect(DateTime.parse(input["startTime"])).to eq(event[:start_time])
-        expect(DateTime.parse(input["endTime"])).to eq(event[:end_time])
-        expect(input["all_day"]).to_not be
-      end
-      example "All day event" do
-        event = FactoryBot.create(:event, start_time: nil, end_time: nil, all_day: true)
-        input = JSON.parse(json_ld(event))
-        expect(input["endTime"]).to be nil
-        expect(input["startTime"]).to be nil
-      end
+    it "returns parseable json" do
+      expect(JSON.parse(ld)).to eql("one" => 2)
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -55,4 +55,54 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  context "JSON-LD" do
+    describe "Common fields" do
+      let(:event) { FactoryBot.create(:event) }
+      subject { JSON.parse(json_ld(event)) }
+
+      it "has common values" do
+        expect(subject["@context"]).to eq "http://schema.org"
+        expect(subject["@type"]).to eq "Event"
+        expect(subject["name"]).to eq event[:title]
+        expect(subject["description"]).to eq event[:description]
+      end
+    end
+    describe "Location" do
+      example "campus building" do
+        building = FactoryBot.create(:building)
+        event = FactoryBot.create(:event, building: building)
+        input = JSON.parse(json_ld(event))
+        expect(input["location"]["@type"]).to eq "Place"
+        expect(input["location"]["name"]).to eq building.name
+      end
+
+      example "Location is external building" do
+        event = FactoryBot.create(:event)
+        input = JSON.parse(json_ld(event))
+        expect(input["location"]["@type"]).to eq "Place"
+        expect(input["location"]["name"]).to eq event[:external_building]
+        expect(input["location"]["address"]["@type"]).to eq "PostalAddress"
+        expect(input["location"]["address"]["streetAddress"]).to eq event[:external_address]
+        expect(input["location"]["address"]["addressRegion"]).to eq event[:external_state]
+        expect(input["location"]["address"]["postalCode"]).to eq event[:external_zip]
+      end
+    end
+
+    describe "timed event" do
+      example "start and end time" do
+        event = FactoryBot.create(:event)
+        input = JSON.parse(json_ld(event))
+        expect(DateTime.parse(input["startTime"])).to eq(event[:start_time])
+        expect(DateTime.parse(input["endTime"])).to eq(event[:end_time])
+        expect(input["all_day"]).to_not be
+      end
+      example "All day event" do
+        event = FactoryBot.create(:event, start_time: nil, end_time: nil, all_day: true)
+        input = JSON.parse(json_ld(event))
+        expect(input["endTime"]).to be nil
+        expect(input["startTime"]).to be nil
+      end
+    end
+  end
+
 end

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -3,56 +3,6 @@
 require "rails_helper"
 
 RSpec.describe EventHelper, type: :helper do
-  context "JSON-LD" do
-    describe "Common fields" do
-      let(:event) { FactoryBot.create(:event) }
-      subject { JSON.parse(json_ld(event)) }
-
-      it "has common values" do
-        expect(subject["@context"]).to eq "http://schema.org"
-        expect(subject["@type"]).to eq "Event"
-        expect(subject["name"]).to eq event[:title]
-        expect(subject["description"]).to eq event[:description]
-      end
-    end
-    describe "Location" do
-      example "campus building" do
-        building = FactoryBot.create(:building)
-        event = FactoryBot.create(:event, building: building)
-        input = JSON.parse(json_ld(event))
-        expect(input["location"]["@type"]).to eq "Place"
-        expect(input["location"]["name"]).to eq building.name
-      end
-
-      example "Location is external building" do
-        event = FactoryBot.create(:event)
-        input = JSON.parse(json_ld(event))
-        expect(input["location"]["@type"]).to eq "Place"
-        expect(input["location"]["name"]).to eq event[:external_building]
-        expect(input["location"]["address"]["@type"]).to eq "PostalAddress"
-        expect(input["location"]["address"]["streetAddress"]).to eq event[:external_address]
-        expect(input["location"]["address"]["addressRegion"]).to eq event[:external_state]
-        expect(input["location"]["address"]["postalCode"]).to eq event[:external_zip]
-      end
-    end
-
-    describe "timed event" do
-      example "start and end time" do
-        event = FactoryBot.create(:event)
-        input = JSON.parse(json_ld(event))
-        expect(DateTime.parse(input["startTime"])).to eq(event[:start_time])
-        expect(DateTime.parse(input["endTime"])).to eq(event[:end_time])
-        expect(input["all_day"]).to_not be
-      end
-      example "All day event" do
-        event = FactoryBot.create(:event, start_time: nil, end_time: nil, all_day: true)
-        input = JSON.parse(json_ld(event))
-        expect(input["endTime"]).to be nil
-        expect(input["startTime"]).to be nil
-      end
-    end
-  end
-
   describe "Get Building Name" do
     context "receives string with translation" do
       it "renders the translation" do

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -91,6 +91,47 @@ RSpec.describe Building, type: :model do
     end
   end
 
+  describe "Makes Linked Data hash" do
+    let(:city) { "Philadelphia" }
+    let(:state) { "PA" }
+    let(:zip_code) { "19122" }
+    let(:building) { FactoryBot.create(:building, :with_image, address2: "#{city}, #{state}, #{zip_code}") }
+
+    describe "Linked data hash" do
+      subject { building.to_ld }
+
+      it { is_expected.to include("name" => building[:name]) }
+      it { is_expected.to include("description" => building[:description]) }
+      it { is_expected.to include("location") }
+
+      describe "location" do
+        subject { building.to_ld["location"] }
+
+        it { is_expected.to include("@type" => "Place") }
+        it { is_expected.to include("address") }
+
+        describe "address" do
+          subject { building.to_ld["location"]["address"] }
+
+          it { is_expected.to include("@type" => "PostalAddress") }
+          it { is_expected.to include("streetAddress" => building.address1) }
+          it { is_expected.to include("addressLocality" => city) }
+          it { is_expected.to include("addressRegion" => state) }
+          it { is_expected.to include("postalCode" => zip_code) }
+        end
+      end
+
+      it { is_expected.to include("telephone" => building[:phone_number]) }
+      it { is_expected.to include("email" => building[:email]) }
+      it { is_expected.to include("image" => Rails.application.routes.url_helpers.rails_representation_url(building.show_image)) }
+      xit { is_expected.to include("hours" => building[:hours]) }
+      it { is_expected.to include("containedInPlace" => building[:campus]) }
+      it { is_expected.to include("geo" => building[:coordinates]) }
+      it { is_expected.to include("googleId" => building[:google_id]) }
+    end
+
+  end
+
   it_behaves_like "categorizable"
   it_behaves_like "imageable"
 end

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -96,42 +96,48 @@ RSpec.describe Building, type: :model do
     let(:state) { "PA" }
     let(:zip_code) { "19122" }
     let(:building) { FactoryBot.create(:building, :with_image, address2: "#{city}, #{state}, #{zip_code}") }
+    let(:building_no_image) { FactoryBot.create(:building) }
 
     describe "Linked data hash" do
-      subject { building.to_ld }
+      subject { building.map_to_schema_dot_org }
 
       it { is_expected.to include("name" => building[:name]) }
       it { is_expected.to include("description" => building[:description]) }
       it { is_expected.to include("location") }
 
       describe "location" do
-        subject { building.to_ld["location"] }
+        subject { building.map_to_schema_dot_org["location"] }
 
-        it { is_expected.to include("@type" => "Place") }
+        it { is_expected.to include("@type" => "https://schema.org/Place") }
         it { is_expected.to include("address") }
 
         describe "address" do
-          subject { building.to_ld["location"]["address"] }
+          subject { building.map_to_schema_dot_org["location"]["address"] }
 
-          it { is_expected.to include("@type" => "PostalAddress") }
+          it { is_expected.to include("@type" => "https://schema.org/PostalAddress") }
           it { is_expected.to include("streetAddress" => building.address1) }
-          it { is_expected.to include("addressLocality" => city) }
-          it { is_expected.to include("addressRegion" => state) }
-          it { is_expected.to include("postalCode" => zip_code) }
+          it { is_expected.to include("addressLocality" => a_string_including(city)) }
+          it { is_expected.to include("addressLocality" => a_string_including(state)) }
+          it { is_expected.to include("addressLocality" => a_string_including(zip_code)) }
         end
       end
 
       it { is_expected.to include("telephone" => building[:phone_number]) }
       it { is_expected.to include("email" => building[:email]) }
-      it { is_expected.to include("image" => Rails.application.routes.url_helpers.rails_representation_url(building.show_image)) }
+      it { is_expected.to include("image" => building.index_image_url) }
       xit { is_expected.to include("hours" => building[:hours]) }
-      it { is_expected.to include("containedInPlace" => building[:campus]) }
       it { is_expected.to include("geo" => building[:coordinates]) }
       it { is_expected.to include("googleId" => building[:google_id]) }
-    end
 
+      context "building without an image" do
+        it "does not include an image tag" do
+          expect(building_no_image.map_to_schema_dot_org.keys).not_to include("image")
+        end
+      end
+    end
   end
 
   it_behaves_like "categorizable"
   it_behaves_like "imageable"
+  it_behaves_like "SchemaDotOrgable"
 end

--- a/spec/models/concerns/schema_dot_orgable.rb
+++ b/spec/models/concerns/schema_dot_orgable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchemaDotOrgable do
+
+  let(:base_attributes) { entity.base_attributes }
+  let(:map_to_schema_dot_org) { entity.map_to_schema_dot_org }
+
+  context "a class that correctly includes the concern" do
+    let(:entity) do
+      class ValidSchema
+        include(SchemaDotOrgable)
+        def label() "label" end
+        def description() "description" end
+        def schema_dot_org_type() "Valid" end
+        def additional_schema_dot_org_attributes() { test: "banana" } end
+      end
+      ValidSchema.new
+    end
+
+    describe "base_attributes" do
+      subject { base_attributes }
+      it { is_expected.to include("@context" => "https://schema.org") }
+      it { is_expected.to include(name: "label") }
+      it { is_expected.to include("@type" => "Valid") }
+    end
+
+    describe "map_to_schema_dot_org" do
+      it "includes all of the base_attributes" do
+        expect(map_to_schema_dot_org).to include(base_attributes)
+      end
+      it "includes entity defined additional_attributes" do
+        expect(map_to_schema_dot_org).to include(test: "banana")
+
+      end
+    end
+  end
+
+  context "a class that incorrectly includes the concern" do
+    let(:entity) {
+      class InvalidSchema
+        include SchemaDotOrgable
+      end
+      InvalidSchema.new
+    }
+    describe "map_to_schema_dot_org" do
+      it "returns an empty hash" do
+        expect(map_to_schema_dot_org).to eql({})
+      end
+    end
+
+  end
+end

--- a/spec/support/imageable_spec.rb
+++ b/spec/support/imageable_spec.rb
@@ -20,4 +20,51 @@ RSpec.shared_examples "imageable" do
       expect(factory_model.image.attachment).to be_nil
     end
   end
+
+  context "image_path route helpers" do
+    context "when an image is attached" do
+      before { image }
+
+      it "has a thumbnail path" do
+        expect(factory_model.thumb_image_path).to include("#{factory_model.id}/image/thumbnail")
+        expect(factory_model.thumb_image_path).to start_with("/")
+      end
+
+      it "has a thumbnail url" do
+        expect(factory_model.thumb_image_url).to include("#{factory_model.id}/image/thumbnail")
+        expect(factory_model.thumb_image_url).to start_with("http")
+      end
+
+      it "has a index path" do
+        expect(factory_model.index_image_path).to include("#{factory_model.id}/image/medium")
+        expect(factory_model.index_image_path).to start_with("/")
+      end
+
+      it "has a index url" do
+        expect(factory_model.index_image_path).to include("#{factory_model.id}/image/medium")
+        expect(factory_model.index_image_url).to start_with("http")
+      end
+
+      it "has a show path" do
+        expect(factory_model.show_image_path).to include("#{factory_model.id}/image/large")
+        expect(factory_model.show_image_path).to start_with("/")
+      end
+
+      it "has a show url" do
+        expect(factory_model.show_image_path).to include("#{factory_model.id}/image/large")
+        expect(factory_model.show_image_url).to include("http://")
+      end
+    end
+
+    context "when an image is not attached" do
+      it "does not raise an error" do
+        expect { factory_model.thumb_image_url }.not_to raise_error
+      end
+
+      it "does not raise an error" do
+        expect { factory_model.thumb_image_url }.not_to raise_error
+      end
+
+    end
+  end
 end

--- a/spec/support/schema_dot_orgable.rb
+++ b/spec/support/schema_dot_orgable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.shared_examples "SchemaDotOrgable" do
+  let(:model) { described_class } # the class that includes the concern
+  let(:factory_model) { FactoryBot.create(model.to_s.underscore.to_sym) }
+
+  it "has defined a schema_dot_org_type method" do
+    expect(factory_model).to respond_to(:schema_dot_org_type)
+  end
+
+  it "safely merges additional attributes" do
+    expect { factory_model.map_to_schema_dot_org }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Creates structured data for buildings.

Refactor to create the JSON-LD with a method to create the LD hash in the model and converting that into JSON in an Application Helper. Applied this refactor to Events and Buildings.