### PR TITLE
[BL-1017] Fix dummy_range field bug.

### DIFF
--- a/app/views/application/_header-search.html.erb
+++ b/app/views/application/_header-search.html.erb
@@ -3,6 +3,7 @@
 		<label for="librarySearch" class="visuallyhidden"><%= t("manifold.header.search.everything") %></label>
 	  <input type="text" name="q" id="librarySearch" placeholder="Search everything" autocomplete="off" />
 	  <input type="submit" value = "" aria-label="submit search query">
+	  <input type="hidden" name="search_field" id="search_field" value="all">
 	</form>
 	<ul class="text-left">
 	  <li><%= link_to t("manifold.header.search.books"), "#{librarysearch_url("books")}" %></li>

--- a/app/views/application/_mobile-search.html.erb
+++ b/app/views/application/_mobile-search.html.erb
@@ -6,6 +6,7 @@
         <label for="librarySearch" class="visuallyhidden"><%= t("manifold.header.search.everything") %></label>
         <input type="text" name="q" id="librarySearch" class="mobile" placeholder="Search everything" autocomplete="off" />
         <input type="submit" class="mobile" value = "" aria-label="submit search query">
+        <input type="hidden" name="search_field" id="search_field" value="all">
       </form>
       <ul class="text-center">
         <li><%= link_to t("manifold.header.search.books"), "#{librarysearch_url("books")}" %></li>

--- a/app/views/application/_page-search.html.erb
+++ b/app/views/application/_page-search.html.erb
@@ -3,5 +3,6 @@
 		<label for="librarySearch" class="visuallyhidden"><%= t("manifold.header.search.everything") %></label>
 	  <input type="text" class="text-left" name="q" id="librarySearch" placeholder="Search everything" autocomplete="off" />
 	  <input type="submit" value = "" aria-label="submit search query">
+	  <input type="hidden" name="search_field" id="search_field" value="all">
 	</form>
 </div>


### PR DESCRIPTION
Blacklight Raange Limit adds search_field=dummy_range if dummy_range is
not set in the query.  This seems to be an outdated requirement that I'm
trying to get removed and thus fix issue, but in the mean time we can
fix our issue simply by making sure we set the param searc_field=all
when submitting queries to the catalog.

REF: https://github.com/projectblacklight/blacklight_range_limit/pull/109
REF: BL-1017