### PR TITLE
Add Entity ownership to AdminGroups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.5.1"
 
 gem "administrate"
 gem "ancestry"
+gem "attr_json"
 gem "auto_strip_attributes"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    attr_json (0.7.0)
+      activerecord (>= 5.0.0, < 6.1)
     auto_strip_attributes (2.5.0)
       activerecord (>= 4.0)
     autoprefixer-rails (9.6.1.1)
@@ -550,6 +552,7 @@ PLATFORMS
 DEPENDENCIES
   administrate
   ancestry
+  attr_json
   auto_strip_attributes
   aws-sdk-s3
   bootsnap (>= 1.1.0)

--- a/app/dashboards/admin_group_dashboard.rb
+++ b/app/dashboards/admin_group_dashboard.rb
@@ -9,10 +9,14 @@ class AdminGroupDashboard < Administrate::BaseDashboard
   # Each different type represents an Administrate::Field object,
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
+
   ATTRIBUTE_TYPES = {
     members: Field::HasMany.with_options(class_name: "Account"),
     id: Field::Number,
     name: Field::String,
+    managed_entities: MultiSelectField.with_options(
+      collection: AdminGroup.manageable_entity_types
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,7 +30,6 @@ class AdminGroupDashboard < Administrate::BaseDashboard
   id
   name
   members
-  created_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -34,9 +37,10 @@ class AdminGroupDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
   id
   name
+  members
+  managed_entities
   created_at
   updated_at
-  members
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -45,6 +49,7 @@ class AdminGroupDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
   members
   name
+  managed_entities
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/admin_group.rb
+++ b/app/models/admin_group.rb
@@ -1,5 +1,53 @@
 # frozen_string_literal: true
 
 class AdminGroup < ApplicationRecord
+  include AttrJson::Record
+  include AttrJson::Record::QueryScopes
+
+  attr_json :managed_entities, :string, array: true, default: []
+  validate :valid_managed_entity_types
+  validate :manged_entities_uniqueness
+
   has_many :members, class_name: "Account"
+
+
+  private
+
+    def manged_entities_uniqueness
+      managed = managed_entities.select { |me| entity_already_managed?(me) }
+      if managed.any?
+        errors.add(:manged_entities, "Some Entity Types are already managed: #{managed.join(', ')}")
+      end
+    end
+
+    def entity_already_managed?(entity_type)
+      (AdminGroup.jsonb_contains(managed_entities: entity_type) - [self]).present?
+    end
+
+    def valid_managed_entity_types
+      unknown_types = managed_entities - manageable_entity_types
+      unless unknown_types.empty?
+        errors.add(:manged_entities, "Some provided Entity Types are not valid : #{unknown_types.join(', ')}")
+      end
+    end
+
+    def self.manageable_entity_types
+      %w{ Blog
+          Building
+          Event
+          Exhibition
+          ExternalLink
+          FindingAid
+          Group
+          Highlight
+          LibraryHour
+          Person
+          Policy
+          Redirect
+      }
+    end
+
+    def manageable_entity_types
+      self.class.manageable_entity_types
+    end
 end

--- a/app/views/fields/multi_select_field/_form.html.erb
+++ b/app/views/fields/multi_select_field/_form.html.erb
@@ -11,8 +11,8 @@
           :to_s,
           selected: field.data.presence,
         ),
-        { include_blank: true }, 
-        { multiple: true, size: field.selectable_options.count+1 }
+        { include_blank: true, include_hidden: false }, 
+        { multiple: true, size: field.selectable_options.count+1}
       )  %>
 
   <div class="text-center">(Hold CTRL to select multiple options)</div>

--- a/db/migrate/20191022194027_add_json_attributes_to_admin_group.rb
+++ b/db/migrate/20191022194027_add_json_attributes_to_admin_group.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddJsonAttributesToAdminGroup < ActiveRecord::Migration[5.2]
+  def change
+    add_column :admin_groups, :json_attributes, :jsonb
+
+    add_index :admin_groups, :json_attributes, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_173423) do
+ActiveRecord::Schema.define(version: 2019_10_22_194027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 2019_10_22_173423) do
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false
     t.boolean "alertability"
-    t.string "name"
     t.bigint "admin_group_id"
+    t.string "name"
     t.index ["admin_group_id"], name: "index_accounts_on_admin_group_id"
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true
@@ -72,6 +72,8 @@ ActiveRecord::Schema.define(version: 2019_10_22_173423) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "json_attributes"
+    t.index ["json_attributes"], name: "index_admin_groups_on_json_attributes", using: :gin
   end
 
   create_table "alerts", force: :cascade do |t|


### PR DESCRIPTION
Allows AdminGroups to be indicated as owners of a Entity type

From JIRA
> The following models should have group ownership at the model level. Ideally, the group ownership would be assigned at the list view and apply to all entities within that model. 
Blogs
Buildings
Events
Exhibitions
External Links
Finding Aids
Groups
Highlights
Library Hours
People
Policies
Redirects