### PR TITLE
Only display date/time widget if system can retrieve date/time

### DIFF
--- a/app/views/application/_todays_date.html.erb
+++ b/app/views/application/_todays_date.html.erb
@@ -1,3 +1,5 @@
+<% unless @todays_hours.nil? %>
 <h2><%= t("manifold.header.todays_hours") %></h2>
 <strong>Charles Library | <%= @todays_hours.hours %></strong><br />
 <%= link_to t("manifold.header.all_hours"), hours_path %> >
+<% end %>


### PR DESCRIPTION
This is to match hotfix applied to master this morning.