### PR TITLE
Display account_admin resource name

### DIFF
--- a/app/dashboards/admin_group_dashboard.rb
+++ b/app/dashboards/admin_group_dashboard.rb
@@ -68,7 +68,7 @@ class AdminGroupDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(admin_group)
-    "Admin Group ##{admin_group.id}"
+    "#{admin_group.name}"
   end
 
   def tinymce?


### PR DESCRIPTION
MAN-650 Request: Please update the drop-down for "Group name" to pull the names of the groups instead of the numbers. Right now, it reads "Admin group #1" instead of "Library Administration"