### PR TITLE
Render show page button on categories show page

### DIFF
--- a/app/views/admin/categories/show.html.erb
+++ b/app/views/admin/categories/show.html.erb
@@ -30,6 +30,11 @@ as well as a link to its edit page.
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
   </div>
+  <% if Rails.application.routes.url_helpers.method_defined?(page.resource.class.name.downcase + "_path") %>
+  <div>
+    <%= link_to(t("manifold.admin.actions.show_website"), page.resource, class: "button green")  %>
+  </div>
+  <% end %>
 </header>
 
 <section class="main-content__body">


### PR DESCRIPTION
- Categories show page overrides default and won't pickup
  the show_website button defined in the application/show.html.erb