### PR TITLE
Update pages path to webpages in swagger

### DIFF
--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Swager", type: :feature do
+
+  before(:all) do
+
+    FactoryBot.create(:person)
+
+  end
+  context "Swagger Spec File" do
+    paths = JSON.load(Rails.root.join("swagger", "swagger.json"))["paths"].keys
+    paths.each do |path|
+      scenario "Visit #{path}" do
+        visit("#{path}.json")
+        expect { JSON.load(page.html) }.not_to raise_error
+
+      end
+    end
+  end
+end

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -813,7 +813,7 @@
         }
       }
     },
-    "/pages": {
+    "/webpages": {
       "get": {
         "summary": "Retrieves a list of pages",
         "tags": ["Webpage", "Batch"],


### PR DESCRIPTION
The route changed, but the path defined in swagger had not been updated. This updates the webpages path in swagger and adds some smoke testing to ensure that all paths defined in swagger return valid json.