### PR TITLE
MAN-855 - Make string ordering test unambiguous

### DIFF
--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -4,7 +4,7 @@ include ActionDispatch::TestProcess
 
 FactoryBot.define do
   factory :building do
-    sequence(:name) { |n| "Charles Samuel Addams Library #{n}" }
+    sequence(:name) { |n| "Charles Samuel Addams Library %03d" % n }
     description { "Main Campus Main Library" }
     address1 { "1250 Polett Walk" }
     address2 { "Philadelphia, PA 19122" }


### PR DESCRIPTION
- Categories, when unweighted should show records in alphabetical
  order of their name or title. But we have sequentially numbered
  names generated by FactoryBot. So the alphabetical order of
  "Building 99" and "Building 100" will be reversed because '1'
  will come before '9'. For this test, explicitly name the buildings
  to prevent this from happening.