### PR TITLE
#MAN-864 Can't save External Link because of slug?

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -6,7 +6,6 @@ class Blog < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   has_many :blog_posts, dependent: :destroy
 

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -15,7 +15,6 @@ class Building < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   before_validation :normalize_phone_number
   before_validation :sanitize_description

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,7 +7,6 @@ class Category < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   has_many :categorizations, dependent: :destroy
   accepts_nested_attributes_for :categorizations

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -11,7 +11,6 @@ class Collection < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   validates :name, :description, presence: true
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,7 +9,6 @@ class Event < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   paginates_per 5
   belongs_to :building, optional: true

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -10,7 +10,6 @@ class Exhibition < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   belongs_to :group, optional: true
   belongs_to :space, optional: true

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -7,7 +7,6 @@ class ExternalLink < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   before_save :link_cleanup!
 

--- a/app/models/finding_aid.rb
+++ b/app/models/finding_aid.rb
@@ -9,7 +9,6 @@ class FindingAid < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   paginates_per 15
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,7 +10,6 @@ class Group < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   validates :name, :chair_dept_heads, presence: true
   validates :group_type, presence: true, group_type: true

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -6,7 +6,6 @@ class Highlight < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   serialize :tags
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -9,7 +9,6 @@ class Person < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   paginates_per 20
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -12,7 +12,6 @@ class Policy < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   has_draft :description
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -13,7 +13,6 @@ class Service < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   validates :title, :description, :intended_audience, presence: true
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -16,7 +16,6 @@ class Space < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/webpage.rb
+++ b/app/models/webpage.rb
@@ -10,7 +10,6 @@ class Webpage < ApplicationRecord
   include SchemaDotOrgable
   friendly_id :title, use: [:slugged, :finders]
   friendly_id :slug_candidates, use: :slugged
-  validates :slug, presence: true
 
   has_one_attached :document, dependent: :destroy
 

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -32,7 +32,11 @@ as well as a link to its edit page.
   </div>
   <% if Rails.application.routes.url_helpers.method_defined?(page.resource.class.name.underscore + "_path") %>
   <div>
+    <% unless page.resource.class.name == "ExternalLink" %>
     <%= link_to(t("manifold.admin.actions.show_website"), url_for(page.resource.class)+"/"+page.resource.id.to_s, class: "button green")  %>
+    <% else %>
+    <%= link_to(t("manifold.admin.actions.show_website"), url_for(page.resource.class.name.underscore)+"/"+page.resource.id.to_s, class: "button green")  %>
+    <% end %>
   </div>
   <% end %>
 </header>


### PR DESCRIPTION
Removes the validation for slug so friendly_id gem can generate new one on save. 

Also updates admin/show route for external links (was being set as exernal_links_path(:id) which does not exist.