### PR TITLE
#MAN-875 Redirects are not working

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -28,7 +28,11 @@ class CollectionsController < ApplicationController
 
   private
     def set_collection
-      @collection = Collection.friendly.find(params[:id])
+      if Collection.find_by(slug: params[:id])
+        @collection = Collection.friendly.find(params[:id])
+      else
+        @collection = Collection.find_by(id: params[:id])
+      end
       return redirect_or_404 unless @collection
       @categories = @collection.categories
     end

--- a/app/controllers/concerns/has_categories.rb
+++ b/app/controllers/concerns/has_categories.rb
@@ -11,7 +11,7 @@ module HasCategories
       else
         link = '<li class="selected">'
       end
-      link += '<a href="' + url_for(c) + '">' + c.label + "</a></li>"
+      link += '<a href="' + get_link(c) + '">' + c.label + "</a></li>"
       links << link
     end
     links
@@ -19,9 +19,9 @@ module HasCategories
 
   protected
 
-    def url_for(options = {})
+    def get_link(options = {})
       obj = options[:slug]
       options[:slug] = obj
-      super(options)
+      url_for(options)
     end
 end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Collections", type: :request do
   describe "a request for /collection/integer when collection does not exist" do
     it "renders the collection" do
       expect { get collection_path(collection.id + 1) }
-        .to raise_error(ActiveRecord::RecordNotFound)
+        .to raise_error(ActionController::RoutingError)
     end
   end
 


### PR DESCRIPTION
Restores find_by in Collections controller when friendly_is is not available. 
Updates redirect_or_404 to use method other than url_for to create link.