### PR TITLE
Events Video

### DIFF
--- a/app/controllers/webpages_controller.rb
+++ b/app/controllers/webpages_controller.rb
@@ -68,17 +68,21 @@ class WebpagesController < ApplicationController
 
   def videos_show
     @displayMode = "show"
-    api_query = @basepath + "/content/" + URI::encode(params[:id])
-    ensemble_api(api_query)
-    unless @videos.nil?
-      @featured_video_id = @videos[:ID]
-      @featured_video_title = @videos[:Title]
-      @featured_video_description = CGI.unescapeHTML(@videos[:Description]) unless @videos[:Description].nil?
+    unless params[:id].nil?
+      api_query = @basepath + "/content/" + URI::encode(params[:id])
+      ensemble_api(api_query)
+      unless @videos.nil?
+        @featured_video_id = @videos[:ID]
+        @featured_video_title = @videos[:Title]
+        @featured_video_description = CGI.unescapeHTML(@videos[:Description]) unless @videos[:Description].nil?
+      else
+        return redirect_to(webpages_videos_all_path, alert: "Unable to retrieve video.")
+      end
+      if @featured_video_id.nil?
+        return redirect_to(webpages_videos_all_path, alert: "Unable to retrieve video.")
+      end
     else
-      return redirect_to(webpages_videos_all_path, alert: "Unable to retrieve video.")
-    end
-    if @featured_video_id.nil?
-      return redirect_to(webpages_videos_all_path, alert: "Unable to retrieve video.")
+      return redirect_to(webpages_videos_all_path, alert: "You must choose a video to stream.")
     end
   end
 


### PR DESCRIPTION
Bug not affecting normal operation, but if no id is passed to the show function, an error is generated. this redirects user back to main video page with warning that a video must be selected.

https://app.honeybadger.io/projects/61882/faults/62244496
