### PR TITLE
Redirects Fix

### DIFF
--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -26,7 +26,12 @@ class BuildingsController < ApplicationController
 
   private
     def set_building
-      @building = Building.friendly.find(params[:id])
+      if Buidling.find_by(slug: params[:id])
+        @building = Buidling.friendly.find(params[:id])
+      else
+        @building = Buidling.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @building
       @categories = @building.categories
     end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -53,6 +53,11 @@ class CategoriesController < ApplicationController
 
   private
     def set_category
-      @category = Category.friendly.find(params[:id])
+      if Category.find_by(slug: params[:id])
+        @category = Category.friendly.find(params[:id])
+      else
+        @category = Category.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @category
     end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -99,7 +99,12 @@ class EventsController < ApplicationController
     end
 
     def set_event
-      @event = Event.friendly.find(params[:id])
+      if Event.find_by(slug: params[:id])
+        @event = Event.friendly.find(params[:id])
+      else
+        @event = Event.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @event
       @event_url = @event.event_url
     end
 end

--- a/app/controllers/exhibitions_controller.rb
+++ b/app/controllers/exhibitions_controller.rb
@@ -20,6 +20,11 @@ class ExhibitionsController < ApplicationController
 
   private
     def set_exhibition
-      @exhibition = Exhibition.friendly.find(params[:id])
+      if Exhibition.find_by(slug: params[:id])
+        @exhibition = Exhibition.friendly.find(params[:id])
+      else
+        @exhibition = Exhibition.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @exhibition
     end
 end

--- a/app/controllers/finding_aids_controller.rb
+++ b/app/controllers/finding_aids_controller.rb
@@ -50,7 +50,12 @@ class FindingAidsController < ApplicationController
 
   private
     def set_finding_aid
-      @finding_aid = FindingAid.friendly.find(params[:id])
+      if FindingAid.find_by(slug: params[:id])
+        @finding_aid = FindingAid.friendly.find(params[:id])
+      else
+        @finding_aid = FindingAid.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @finding_aid
       @title = @finding_aid.label
       blockson = Collection.find_by(slug: "blockson_collection")
       @aeon = @finding_aid.collections.include?(blockson)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,12 @@ class GroupsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_group
-      @group = Group.friendly.find(params[:id])
+      if Group.find_by(slug: params[:id])
+        @group = Group.friendly.find(params[:id])
+      else
+        @group = Group.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @group
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/highlights_controller.rb
+++ b/app/controllers/highlights_controller.rb
@@ -20,6 +20,11 @@ class HighlightsController < ApplicationController
 
   private
     def set_highlight
-      @highlight = Highlight.friendly.find(params[:id])
+      if Highlight.find_by(slug: params[:id])
+        @highlight = Highlight.friendly.find(params[:id])
+      else
+        @highlight = Highlight.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @highlight
     end
 end

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -27,6 +27,11 @@ class PoliciesController < ApplicationController
 
   private
     def set_policy
-      @policy = Policy.friendly.find(params[:id])
+      if Policy.find_by(slug: params[:id])
+        @policy = Policy.friendly.find(params[:id])
+      else
+        @policy = Policy.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @policy
     end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -29,8 +29,11 @@ class ServicesController < ApplicationController
 
   private
     def set_service
-      # binding.pry
-      @service = Service.friendly.find(params[:id])
+      if Service.find_by(slug: params[:id])
+        @service = Service.friendly.find(params[:id])
+      else
+        @service = Service.find_by(id: params[:id])
+      end
       return redirect_or_404 unless @service
       @categories = @service.categories
     end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -30,7 +30,12 @@ class SpacesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_space
-      @space = Space.friendly.find(params[:id])
+      if Space.find_by(slug: params[:id])
+        @space = Space.friendly.find(params[:id])
+      else
+        @space = Space.find_by(id: params[:id])
+      end
+      return redirect_or_404 unless @space
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.


### PR DESCRIPTION
Since we are now using redirects for internal purposes and not just for old Drupal paths, the logic calling the redirects needed to be extended to all models that could be used as a redirect request.