### PR TITLE
File Upload Friendly Find Fix

### DIFF
--- a/app/dashboards/file_upload_dashboard.rb
+++ b/app/dashboards/file_upload_dashboard.rb
@@ -11,6 +11,7 @@ class FileUploadDashboard < BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
+    slug: Field::String,
     name: Field::String,
     file: FileField
   }.freeze
@@ -29,6 +30,7 @@ class FileUploadDashboard < BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
     :id,
+    :slug,
     :name,
     :file
   ].freeze
@@ -38,6 +40,7 @@ class FileUploadDashboard < BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
+    :slug,
     :file
   ].freeze
 

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -3,7 +3,15 @@
 class FileUpload < ApplicationRecord
   # has_paper_trail
   include Validators
+  extend FriendlyId
+  friendly_id :name, use: [:slugged, :finders]
+
   has_one_attached :file, dependent: :destroy
+
   validates :name, presence: true
   validates :file, content_type: ["application/pdf"]
+
+  def should_generate_new_friendly_id?
+    name_changed? || slug.blank?
+  end
 end

--- a/db/migrate/20200429194118_adds_slug_field_to_file_uploads.rb
+++ b/db/migrate/20200429194118_adds_slug_field_to_file_uploads.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddsSlugFieldToFileUploads < ActiveRecord::Migration[5.2]
+  def change
+    add_column :file_uploads, :slug, :string, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_154745) do
+ActiveRecord::Schema.define(version: 2020_04_29_194118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 2020_03_25_154745) do
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false
     t.boolean "alertability"
-    t.string "name"
     t.bigint "admin_group_id"
+    t.string "name"
     t.index ["admin_group_id"], name: "index_accounts_on_admin_group_id"
     t.index ["email"], name: "index_accounts_on_email", unique: true
     t.index ["reset_password_token"], name: "index_accounts_on_reset_password_token", unique: true
@@ -226,7 +226,6 @@ ActiveRecord::Schema.define(version: 2020_03_25_154745) do
     t.string "event_type"
     t.string "slug"
     t.string "guid"
-    t.string "timestamp_start"
     t.string "event_url"
     t.index ["building_id"], name: "index_events_on_building_id"
     t.index ["person_id"], name: "index_events_on_person_id"
@@ -263,6 +262,7 @@ ActiveRecord::Schema.define(version: 2020_03_25_154745) do
     t.string "attachable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
   end
 
   create_table "fileabilities", force: :cascade do |t|


### PR DESCRIPTION
Add slug field to file uploads to prevent errors when trying edit on the web due to admin/application_controller not knowing what friendly is when trying to set the instance for this model.