### PR TITLE
Exhibition title shouldn't be draftable

### DIFF
--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -15,7 +15,7 @@ class Exhibition < ApplicationRecord
   belongs_to :space, optional: true
   belongs_to :collection, optional: true
 
-  has_draft :title, :description
+  has_draft :description
 
   before_save :sanitize_description
 


### PR DESCRIPTION
Addresses Issue #MAN-922

- Remove leftover attribute from itnitial draftable development
  which was causing a draft field to appear for non-admin user