### PR TITLE
#MAN-933 Hours are not appearing on the homepage

### DIFF
--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -12,7 +12,7 @@ module Admin
       blog = Blog.find(params[:blog_id])
       SyncService::Blogs.call(blog: blog)
       flash[:notice] = t(
-        "fortytude.admin.notification.blog_synced",
+        "manifold.admin.notification.blog_synced",
         title: blog.title,
         id: blog.id
       )

--- a/app/controllers/webpages_controller.rb
+++ b/app/controllers/webpages_controller.rb
@@ -124,6 +124,7 @@ class WebpagesController < ApplicationController
   end
 
   def home
+    @todays_hours = LibraryHour.todays_hours_at("ask_a_librarian")
   end
 
   def scrc

--- a/app/views/application/_todays_date.html.erb
+++ b/app/views/application/_todays_date.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t("manifold.header.todays_hours") %></h2>
 <strong>
-    <%= t("manifold.header.todays_hours_text, hours: @todays_hours.hours") unless @todays_hours.nil? %>
+  <%= t("manifold.header.todays_hours_text", hours: @todays_hours.hours) unless @todays_hours.nil? %>
 </strong>
 <br />
 <%= link_to t("manifold.header.all_hours"), hours_path %> >


### PR DESCRIPTION
Translation call for chat widget not properly quoted in yml file.

Also fixed old translation call on individual blog sync flashes.