### PR TITLE
Revert "Bump faker from 2.12.0 to 2.13.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
-    faker (2.13.0)
+    faker (2.12.0)
       i18n (>= 1.6, < 2)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)


### PR DESCRIPTION
Reverts tulibraries/manifold#1388

Space model spec errors that need to be figured out