### PR TITLE
#MAN-934 Remove text from hours page

### DIFF
--- a/app/views/library_hours/_desktop.html.erb
+++ b/app/views/library_hours/_desktop.html.erb
@@ -16,7 +16,7 @@
       </h2>
     </div>
     <div class="col-9">
-      <%= t("manifold.hours.charles_note_html").html_safe %>
+      <%# t("manifold.hours.charles_note_html").html_safe %>
     </div>
   </div>
 <% end %>

--- a/app/views/library_hours/_mobile.html.erb
+++ b/app/views/library_hours/_mobile.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
     <div class="col-12">
-      <%= t("manifold.hours.charles_note_html").html_safe %>
+      <%# t("manifold.hours.charles_note_html").html_safe %>
     </div>
 <% end %>
 


### PR DESCRIPTION
Removed text in Charles listing

Commented it out so it can easily be reactivated later with text set in en.yml