### PR TITLE
#BL-1242 Update banner integration and styling

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class AlertsController < ApplicationController
+  include SerializableRespondTo
+
   def index
-    @alerts = Alert.all
+    serializable_index
   end
   def show
     @alert = Alert.find(params[:id])

--- a/app/controllers/concerns/serializable_respond_to.rb
+++ b/app/controllers/concerns/serializable_respond_to.rb
@@ -4,7 +4,8 @@ module SerializableRespondTo
   extend ActiveSupport::Concern
 
   def serializable_index
-    @resources = klass.all
+    @resources = klass.all unless klass == Alert
+    @resources = klass.all.where(published: true) if klass == Alert
     respond_to do |format|
       format.html { redirect_to root_path }
       format.json { render json: klass_serializer.new(@resources) }

--- a/app/schemas/alert_schema.json
+++ b/app/schemas/alert_schema.json
@@ -1,0 +1,118 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "http://example.com/root.json",
+	"type": "object",
+	"title": "The Root Schema",
+	"required": [
+		"data"
+	],
+	"properties": {
+		"data": {
+			"$id": "#/properties/data",
+			"type": "object",
+			"title": "The Data Schema",
+			"required": [
+				"id",
+				"type",
+				"attributes"
+			],
+			"properties": {
+				"id": {
+					"$id": "#/properties/data/properties/id",
+					"type": "string",
+					"title": "The Id Schema",
+					"default": "0",
+					"examples": [
+						"2"
+					],
+					"pattern": "^([0-9]*)$"
+				},
+				"type": {
+					"$id": "#/properties/data/properties/type",
+					"type": "string",
+					"title": "The Type Schema",
+					"default": "alert",
+					"examples": [
+						"building",
+						"event",
+						"person"
+					],
+					"pattern": "^(.*)$"
+				},
+				"attributes": {
+					"$id": "#/properties/data/properties/attributes",
+					"type": "object",
+					"title": "The Attributes Schema",
+					"required": [
+						"scroll_text",
+                        "link",
+                        "published",
+						"description"
+					],
+					"properties": {
+						"scroll_text": {
+							"$id": "#/properties/data/properties/attributes/properties/scroll_text",
+							"type": "string",
+							"title": "The Label Schema",
+							"default": "",
+							"examples": [
+								"The Library Collection"
+							],
+							"pattern": "^(.*)$"
+						},
+						"link": {
+							"$id": "#/properties/data/properties/attributes/properties/link",
+							"type": "string",
+							"title": "The Label Schema",
+							"default": "",
+							"examples": [
+								"The Library Collection"
+							],
+							"pattern": "^(.*)$"
+                        },
+						"published": {
+							"$id": "#/properties/data/properties/attributes/properties/published",
+							"type": "boolean",
+							"title": "The Label Schema",
+							"default": true,
+							"examples": [
+								true
+							]
+						},
+						"description": {
+							"$id": "#/properties/data/properties/attributes/properties/description",
+							"type": "string",
+							"title": "The Description Schema",
+							"default": "",
+							"examples": [
+								"This is the description of the collection"
+							],
+							"pattern": "^(.*)$"
+						}
+					}
+				},
+				"links": {
+					"$id": "#/properties/data/properties/links",
+					"type": "object",
+					"title": "The Links Schema",
+					"required": [
+						"self"
+					],
+					"properties": {
+						"self": {
+							"$id": "#/properties/data/properties/links/properties/self",
+							"type": "string",
+							"title": "The Self Schema",
+							"default": "",
+							"examples": [
+								"http://test.host/alert/2"
+							],
+							"pattern": "^(.*)$"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/app/serializers/alert_serializer.rb
+++ b/app/serializers/alert_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlertSerializer
+  include FastJsonapi::ObjectSerializer
+
+  def self.helpers
+    Rails.application.routes.url_helpers
+  end
+
+  attributes :published, :scroll_text, :link, :description, :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
   end
 
   root "webpages#home"
+  resources :alerts, only: [:index]
   resources :buildings, only: [:index, :show], path: "libraries", concerns: [:imageable]
   resources :categories, only: [:index, :show], concerns: [:imageable]
   resources :blogs, only: [:index, :show]

--- a/spec/factories/alerts.rb
+++ b/spec/factories/alerts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :alert do
+    scroll_text { "This is an alert" }
+    link { "http://library.temple.edu" }
+    description { "thjis is a test alert" }
+    published { true }
+
+    trait :unpublished do
+        published { false }
+      end
+  end
+end

--- a/spec/serializers/alert_serializer_spec.rb
+++ b/spec/serializers/alert_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "uri"
+
+RSpec.describe AlertSerializer do
+  let(:alert) { FactoryBot.create(:alert) }
+  let(:serialized) { described_class.new(alert) }
+
+  it "doesn't raise an error when instantiated" do
+    expect { serialized }.not_to raise_error
+  end
+
+  describe "serialized_hash" do
+    let(:sh) { serialized.serializable_hash }
+    let(:data) { sh[:data] }
+
+    it "has the expected type" do
+      expect(data[:type]).to eql :alert
+    end
+
+    it "has the expected attributes" do
+      expect(data[:attributes].keys).to include(:scroll_text, :description, :link, :published)
+    end
+
+    it "returns the scroll_text" do
+      scroll_text = data[:attributes][:scroll_text]
+      expect(scroll_text).to match(data[:attributes][:scroll_text])
+    end
+  end
+  describe "serialized_json" do
+    it "returns valid json" do
+      Tempfile.open(["serialized_alert", ".json"]) do |tempfile|
+        tempfile.write(serialized.to_json)
+        tempfile.close
+        args = %W[validate -s app/schemas/alert_schema.json -d #{tempfile.path}]
+        expect(system("ajv", *args)).to be
+      end
+    end
+  end
+end


### PR DESCRIPTION
First part of coupling the library search alerts to the manifold web site alerts.

Provides endpoint at "/alerts.json" to provide alerts that are currently published.