### PR TITLE
#MAN-948 Error occurred when attempting to delete external link

### DIFF
--- a/app/controllers/admin/external_links_controller.rb
+++ b/app/controllers/admin/external_links_controller.rb
@@ -23,7 +23,7 @@ module Admin
     def destroy
       begin
         super
-      rescue => exception
+      rescue StandardError => error
         link_id = ExternalLink.find_by(slug: params[:id])
         webpages = Webpage.where(external_link_id: link_id)
         collections = Collection.where(external_link_id: link_id)
@@ -56,13 +56,6 @@ module Admin
         end
         redirect_to :admin_external_links, notice: notice
 
-      end
-    end
-
-    def detach(models = [])
-      models.each do |model|
-        model.external_link_id = nil
-        model.save
       end
     end
   end

--- a/app/models/external_link.rb
+++ b/app/models/external_link.rb
@@ -10,13 +10,6 @@ class ExternalLink < ApplicationRecord
 
   before_save :link_cleanup!
 
-  # has_many :collection, dependent: :restrict_with_error
-  has_many :webpage, dependent: :restrict_with_error
-  has_many :category, dependent: :restrict_with_error
-  has_many :space, dependent: :restrict_with_error
-  has_many :service, dependent: :restrict_with_error
-  has_many :building, dependent: :restrict_with_error
-
   validates :title, :link, presence: true
 
   def slug_candidates


### PR DESCRIPTION
Remove restrictions in model in favor of overridden destroy method in admin controller. 
They were clashing and we were not getting the custom message.