### PR TITLE
#MAN-984 Library Events Page, Wrong Field

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -85,14 +85,14 @@ class EventsController < ApplicationController
       @exhibitions = Exhibition.where(promoted_to_events: true)
       @today = Date.current
       @new_tags = ["Interruption",
-        "Change and Action",
+        "Change And Action",
         "Blockson",
         "Health Sciences",
         "Digital Scholarship",
         "Workshop",
-        "Chat in the Stacks",
+        "Chat In The Stacks",
         "Midday Arts",
-        "Beyond the Notes",
+        "Beyond The Notes",
         "Book Club",
         "Concert",
         "Reading",

--- a/app/views/events/_featured.html.erb
+++ b/app/views/events/_featured.html.erb
@@ -16,12 +16,10 @@
       <p class="pt-2"><%= sanitize strip_tags(event.description.html_safe.truncate(125)) %></p>
       
       <p>
-        <% unless event.get_types.nil? %>
-          <% event.get_types.each do |type| %>
-            <% unless action_name == "past" %>
+        <% unless event.get_tags.nil? %>
+          <% event.get_tags.each do |type| %>
+            <% if @new_tags.include?(type.titleize) %>
               <%= link_to type, events_path(type: type), class: "event_type" %> 
-            <% else %>
-              <%= link_to type, past_events_path(type: type), class: "event_type" %> 
             <% end %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Featured events display now uses the new tag set.
Updated new tags in controller to match on titleize (called from view).