### PR TITLE
Uncategorized Policies

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -62,4 +62,8 @@ class Building < ApplicationRecord
       googleId: google_id,
     }
   end
+
+  def label
+    name
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -56,4 +56,8 @@ class Category < ApplicationRecord
   def link
     custom_url.presence || self
   end
+
+  def label
+    name
+  end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -52,4 +52,8 @@ class Collection < ApplicationRecord
       }
     }
   end
+
+  def label
+    name
+  end
 end

--- a/app/models/finding_aid.rb
+++ b/app/models/finding_aid.rb
@@ -54,6 +54,10 @@ class FindingAid < ApplicationRecord
     }
   end
 
+  def label
+    name
+  end
+
   private
     # TODO: find and eliminate the cause of nil values on form submission
     def weed_nils

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -54,9 +54,13 @@ class Group < ApplicationRecord
     end
     members.uniq
   end
+
   def todays_hours
     unless space.nil?
       space.todays_hours
     end
+  end
+  def label
+    name
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -62,7 +62,9 @@ class Person < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  alias :label :name
+  def label
+    name
+  end
 
   def burpSpecialties
     if self.specialties.is_a? Array

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -77,4 +77,8 @@ class Space < ApplicationRecord
     end
     arr
   end
+
+  def label
+    name
+  end
 end

--- a/app/views/fields/has_many/_index.html.erb
+++ b/app/views/fields/has_many/_index.html.erb
@@ -8,7 +8,7 @@
 	</ul>
 <% else %>
   <% unless field.resource.class.to_s == "ActiveStorage::Blob" %>
-	  <%= field.data.take.label unless field.data.take.label.nil? %>
+	  <%= field.data.take.label if field.data.take.present? %>
   <% else %>
 	  <%= field.resource.filename.to_s %>
   <% end %>


### PR DESCRIPTION
Policies with no categories were throwing error on admin index page, checking label on nil entries threw the error.

This fix addresses any model with a has_many relationship.

Also added label method to models without it.