### PR TITLE
#MAN-1003 When logging into the backend take user to page

### DIFF
--- a/app/assets/javascripts/administrate/admin_redirect.js
+++ b/app/assets/javascripts/administrate/admin_redirect.js
@@ -1,0 +1,10 @@
+
+$(document).ready(function() {  
+  const queryString = window.location.search
+  const path = window.location.pathname
+  const urlParams = new URLSearchParams(queryString);
+  
+  if (urlParams.get('admin') == "show" || urlParams.get('admin') == "index") {
+    window.location.href = path;
+  }
+});

--- a/app/assets/javascripts/administrate/application.js
+++ b/app/assets/javascripts/administrate/application.js
@@ -1,6 +1,4 @@
 //= require jquery
 //= require jquery_ujs
-//= require selectize
-//= require moment
-//= require datetime_picker
 //= require_tree .
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,23 @@ module ApplicationHelper
   def json_ld(entity)
     raw(entity.map_to_schema_dot_org.to_json)
   end
+
+  def edit_url
+    path = request.env["PATH_INFO"]
+    controller = path.split("/").slice(1)
+    id = path.split("/").slice(2)
+    exemptions = [nil, "library_hours", "webpages"]
+
+    controller == "libraries" ? controller = "buildings" : controller = controller_name
+
+    unless exemptions.include?(controller)
+      "/admin/#{controller}/#{id}?admin=show"
+    else
+      if controller == "webpages" && action_name == "show"
+        "/admin/#{controller}/#{id}?admin=show"
+      else
+        "/admin/#{controller}?admin=index"
+      end
+    end
+  end
 end

--- a/app/views/admin/application/edit.html.erb
+++ b/app/views/admin/application/edit.html.erb
@@ -19,6 +19,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
+    <a name="pagetop"></a>
     <%= content_for(:title) %>
   </h1>
 

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -55,7 +55,10 @@
           </div>
           <div class="row">
             <div class="col p-0" style="margin-top: 28px;">
-              <%= link_to (image_tag "gear.png", style: "width: 22px", class: "decorative", alt: ""), admin_people_path %>
+              <%= link_to (image_tag "gear.png",
+                            style: "width: 22px", 
+                            class: "decorative", 
+                            alt: ""), edit_url %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -1,0 +1,40 @@
+<%#
+# Application Layout
+
+This view template is used as the layout
+for every page that Administrate generates.
+
+By default, it renders:
+- Navigation
+- Content for a search bar
+  (if provided by a `content_for` block in a nested page)
+- Flashes
+- Links to stylesheets and JavaScripts
+%>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+<head>
+  <meta charset="utf-8">
+  <meta name="ROBOTS" content="NOODP">
+  <title>
+    <%= content_for(:title) %> - <%= application_title %>
+  </title>
+  <%= render "stylesheet" %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+  <%= render "icons" %>
+
+  <div class="app-container">
+    <%= render "navigation" -%>
+
+    <main class="main-content" role="main">
+      <%= render "flashes" -%>
+      <%= yield %>
+    </main>
+  </div>
+
+  <%= render "javascript" %>
+</body>
+</html>


### PR DESCRIPTION
- Adjusts the login link in the footer to go to that page's admin page rather than a generic admin landing page.
- Admin page redirects to itself on load to get around a browser based issue where admin pages load scrolled to same position that link was located on in previous page: see note below.

Note on JS redirect: 

- If the login link is added to the header, the admin pages open normally (scrolled to top). 
- If the login link is added to the middle of the page, the admin page opens scrolled down to the middle. 
- If the login link is added to the bottom of the page, the admin page opens scrolled down to the bottom. 
- This appears to be an issue of the rails app loading the admin section but the browser not recognizing the change and thus keeping the scrolled location just as if the page was simply refreshed.