### PR TITLE
Authenticate dockerhub pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
   run_tests:
     docker:
       - image: circleci/ruby:2.6.5-node
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           TZ: "America/New_York"
 
@@ -89,6 +92,9 @@ jobs:
   qa_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -103,6 +109,9 @@ jobs:
   stage_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -117,6 +126,9 @@ jobs:
   prod_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:


### PR DESCRIPTION
dockerhub will begin to throttle non anthenticated pulls so we need to
authenticate our pulls now.