### PR TITLE
AJV-fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
       - run:
           name: Install node packages required for tests
           command: | 
-            sudo npm install -g ajv
-            sudo npm install -g ajv-cli
+            sudo npm install -g ajv@6.12.6
+            sudo npm install -g ajv-cli@3.3.0
       - run:
           name: Ruby Lint
           command: bundle exec rubocop

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe GroupsController, type: :controller do
 
   describe "GET #index" do
     xit "returns json when requested" do
+      # we do not provide serialization for groups
       get :index, format: :json
       expect(response.header["Content-Type"]).to include "json"
     end


### PR DESCRIPTION
Pin AJV npm modules for serialization tests. Add note why groups are skipped.