### PR TITLE
#MAN-1042 link past exhibits to Past programs and Exhibits page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,6 +11,10 @@ class EventsController < ApplicationController
   def index
     events = @all_events.having("start_time >= ?", @today).order(start_time: :asc)
     @events = return_events(events)
+    @exhibitions = Exhibition.where("end_date >= ?", @today)
+                             .where(promoted_to_events: true)
+                             .order(start_date: :desc, end_date: :desc)
+                             .take(2)
     @mailing_list = ExternalLink.find_by(slug: "events-mailing-list")
     @intro = Webpage.find_by(slug: "events-intro")
     respond_to do |format|
@@ -21,6 +25,10 @@ class EventsController < ApplicationController
 
   def past
     events = @all_events.having("start_time < ?", @today).order(start_time: :desc)
+    @exhibitions = Exhibition.where("end_date < ?", @today)
+                   .where(promoted_to_events: true)
+                   .order(end_date: :desc, start_date: :desc)
+                   .take(2)
     @events = return_events(events)
     @intro = Webpage.find_by(slug: "events-intro")
     respond_to do |format|
@@ -82,7 +90,6 @@ class EventsController < ApplicationController
     def init
       @all_events = Event.group(:id)
       @featured_events = Event.where(featured: true).order(:start_time).take(3)
-      @exhibitions = Exhibition.where(promoted_to_events: true)
       @today = Date.current
       @new_tags = ["Interruption",
         "Change And Action",

--- a/app/views/admin/application/edit.html.erb
+++ b/app/views/admin/application/edit.html.erb
@@ -25,7 +25,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
   <div>
     <%= link_to(
-      t("administrate.actions.show_resource", name: page.page_title),
+      t("administrate.actions.show_resource", name: page.resource_name.humanize),
       [namespace, page.resource],
       class: "button",
     ) if valid_action?(:show) && show_action?(:show, page.resource) %>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -25,7 +25,7 @@ as well as a link to its edit page.
 
   <div>
     <%= link_to(
-      t("administrate.actions.edit_resource", name: page.page_title),
+      t("administrate.actions.edit_resource", name: page.resource_name.humanize),
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -65,7 +65,7 @@
 
 <div class="container pr-md-4">
   <div class="row mt-3 mr-lg-2 mb-3 sub-level-background">
-    <div class="col-12 col-lg-8 events pt-3 mb-3" id="events">
+    <div class="col-12 <%= @exhibitions.blank? ? "col-lg-12" : "col-lg-8" %> events pt-3 mb-3" id="events">
       <div class="row">
         <div class="col-12">  
           <h2 class="p-3 mb-3 current-events"><%= t("manifold.events.index.upcoming_events") %></h2>
@@ -84,22 +84,21 @@
 
     </div>
 
+    <% unless @exhibitions.blank? %>
     <div class="col-12 col-lg-4 exhibits">
-    <div class="row">
-    <div class="col-12 pt-3 mb-3" id="events-exhibits">
+      <div class="row">
+        <div class="col-12 pt-3 mb-3" id="events-exhibits">
 
-      <% unless @exhibitions.blank? %>
-        <h2 class="p-3 mb-3 current-exhibits">
-          <%= t("manifold.events.index.current_exhibits_label") %>
-        </h2>
-        
-        <%= render "exhibitions" %>
+            <h2 class="p-3 mb-3 current-exhibits">
+              <%= t("manifold.events.index.current_exhibits_label") %>
+            </h2>
       
-      <% end %>
-
+            <%= render "exhibitions" %>
+        </div>
+      </div>
     </div>
-  </div>
-  </div>
+  <% end %>
+    
     </div>
   </div>
   </div>

--- a/app/views/events/past.html.erb
+++ b/app/views/events/past.html.erb
@@ -87,7 +87,7 @@
 
       <% unless @exhibitions.blank? %>
         <h2 class="p-3 mb-3 current-exhibits">
-          <%= t("manifold.events.index.current_exhibits_label") %>
+          <%= t("manifold.events.index.past_exhibits_label") %>
         </h2>
         
         <%= render "exhibitions" %>

--- a/app/views/exhibitions/show.html.erb
+++ b/app/views/exhibitions/show.html.erb
@@ -1,5 +1,11 @@
 <div class="container exhibit-show">
 
+<div class = "row">
+  <div class="col crumbs">
+    <%= link_to "< All Events & Exhibits", events_path %>
+  </div>
+</div>
+
 <div class="row">
   <div class="d-none d-lg-block col-lg-3">
     <div class="exhibit-image">

--- a/app/views/fields/date_time/_form.html.erb
+++ b/app/views/fields/date_time/_form.html.erb
@@ -2,5 +2,5 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_area field.attribute, class: "tinymce", rows: 10, cols: 120 %>
+  <%= f.text_field field.attribute %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,6 +353,7 @@ en:
       index:
         page_title: "Events & Exhibits"
         current_exhibits_label: "Current Exhibits"
+        past_exhibits_label: "Past Exhibits"
         past_events_label: "Past Events"
         mailing_list: Sign up for our mailing list
         view_current_events: "View current events & exhibits."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,6 +92,8 @@ ActiveRecord::Schema.define(version: 2021_01_11_172125) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
@@ -526,6 +528,7 @@ ActiveRecord::Schema.define(version: 2021_01_11_172125) do
   end
 
   add_foreign_key "accounts", "admin_groups"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "external_links"
   add_foreign_key "collections", "external_links"


### PR DESCRIPTION
Update past events page to show past exhibits. 
Remove titles from show and edit buttons. 
Add back link to exhibit show page.