### PR TITLE
Replace deprecated open method

### DIFF
--- a/app/services/sync_service/blogs.rb
+++ b/app/services/sync_service/blogs.rb
@@ -31,7 +31,7 @@ class SyncService::Blogs
   end
 
   def read_blog_posts
-    blog_feed = Nokogiri::XML(open(@feed_uri))
+    blog_feed = Nokogiri::XML(URI.open(@feed_uri))
     blog_feed.xpath("//channel/item").map do |blog_post|
       blog_post_xml = blog_post.to_xml
       blog_post_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\">" + blog_post.to_xml + "</xml>"

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -15,7 +15,7 @@ class SyncService::Events
     @stdout = Logger.new(STDOUT)
     @eventsUrl = params.fetch(:events_url) || Rails.configuration.events_feed_url
     @force = params.fetch(:force, false)
-    @eventsDoc = Nokogiri::XML(open(@eventsUrl))
+    @eventsDoc = Nokogiri::XML(URI.open(@eventsUrl))
     stdout_and_log("Syncing events from #{@eventsUrl}")
   end
 


### PR DESCRIPTION
- In Nokogiri, replace open with URI.open