### PR TITLE
DEVO-388 Use resolv-replace to handle timeout on QA and Prod

### DIFF
--- a/app/services/sync_service/blogs.rb
+++ b/app/services/sync_service/blogs.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "open-uri"
+require "resolv-replace"
 
 class SyncService::Blogs
   def self.call(blog: nil)

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "open-uri"
+require "resolv-replace"
 require "logger"
 
 class SyncService::Events


### PR DESCRIPTION
- Suspect that QA and Prod attempt to resolve sites.temple.edu over IPV6, which we have seen timeout
- resolv-replace gem fixes Net::OpenTimeout: execution expired problem, providing an alternative means to resolve Domain Names.