### PR TITLE
#MAN-1098 Add models to web content JSON export

### DIFF
--- a/app/serializers/concerns/long_description_serializable.rb
+++ b/app/serializers/concerns/long_description_serializable.rb
@@ -4,7 +4,7 @@ module LongDescriptionSerializable
   extend ActiveSupport::Concern
   included do
     attribute :long_description do |the_object|
-      the_object.long_description.body.to_html
+      the_object.long_description.body
     end
   end
 end


### PR DESCRIPTION
Models already available.

Removed to_html method on long_description causing error on categories output.