### PR TITLE
DEVO-392 Pin Skylight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "rswag-ui"
 gem "sass-rails", "~> 6.0"
 gem "simple_form"
 gem "sitemap_generator"
-gem "skylight", "5.1.1"
+gem "skylight", "4.3.2"
 gem "sqlite3", "~> 1.3.13"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -532,8 +532,10 @@ GEM
     simplecov_json_formatter (0.1.3)
     sitemap_generator (6.1.2)
       builder (~> 3.0)
-    skylight (5.1.1)
-      activesupport (>= 5.2.0)
+    skylight (4.3.2)
+      skylight-core (= 4.3.2)
+    skylight-core (4.3.2)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -666,7 +668,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   sitemap_generator
-  skylight (= 5.1.1)
+  skylight (= 4.3.2)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.13)


### PR DESCRIPTION
- Skylight version 5 does not work with centos 7. We need to remain pinned at 4.3.2 to have it working