### PR TITLE
DEVO-392 Pin Skylight to 4.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "rswag-ui"
 gem "sass-rails", "~> 6.0"
 gem "simple_form"
 gem "sitemap_generator"
-gem "skylight", "5.1.1"
+gem "skylight", "4.3.2"
 gem "sqlite3", "~> 1.3.13"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -532,8 +532,10 @@ GEM
     simplecov_json_formatter (0.1.3)
     sitemap_generator (6.1.2)
       builder (~> 3.0)
-    skylight (5.1.1)
-      activesupport (>= 5.2.0)
+    skylight (4.3.2)
+      skylight-core (= 4.3.2)
+    skylight-core (4.3.2)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -666,7 +668,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   sitemap_generator
-  skylight (= 5.1.1)
+  skylight (= 4.3.2)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.3.13)


### PR DESCRIPTION
It is very important that we pin Skylight to this version and not merge the dependabot updates to bump it.  Version 5 of Skylight is not compatible with Centos7, so we are not getting any data when using it. We haven't had any data for months in this application as a result.  I have pinned this before, but it keeps getting updated before deployment, so the change never gets to production.