### PR TITLE
InRelease' changed its 'Suite' value from 'stable' to 'oldstable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       - run:
           name: bundle install w/ dependent libs
           command: |
+            sudo apt-get --allow-releaseinfo-change update
             sudo apt-get update
             sudo apt-get install postgresql-client
             bundle install --path vendor/bundle


### PR DESCRIPTION
Fixes:

```
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```
