### PR TITLE
MAN-1179 Require description in Finding Aids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,4 +96,5 @@ group :test do
   gem "simplecov-lcov"
   gem "webmock"
   gem "launchy"
+  gem "shoulda-matchers", "~> 5.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,6 +512,8 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     shellany (0.0.1)
+    shoulda-matchers (5.1.0)
+      activesupport (>= 5.2.0)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)
@@ -660,6 +662,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 6.0)
   selenium-webdriver
+  shoulda-matchers (~> 5.1)
   simple_form
   simplecov
   simplecov-lcov

--- a/app/models/finding_aid.rb
+++ b/app/models/finding_aid.rb
@@ -19,6 +19,7 @@ class FindingAid < ApplicationRecord
   has_rich_text :draft_description
   has_rich_text :covid_alert
   validates :collection_id, collection_or_subject: true
+  validates :description, presence: true
 
   scope :has_subjects, -> { where.not(subject: []) }
   scope :has_collections, -> { where.not(collections: []) }

--- a/spec/models/finding_aid_spec.rb
+++ b/spec/models/finding_aid_spec.rb
@@ -4,6 +4,10 @@ require "rails_helper"
 
 RSpec.describe FindingAid, type: :model do
 
+  describe "validations" do
+    it { should validate_presence_of(:description) }
+  end
+
   describe "version all fields", :skip do
     # [TODO] create factory with default collection
     fields = {
@@ -43,7 +47,6 @@ RSpec.describe FindingAid, type: :model do
       expect { finding_aid.save! }.to raise_error(/Values for either Collections or Subjects need to be selected./)
     end
   end
-
 
   describe "Scope" do
     describe ":with_subject" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,4 +93,11 @@ RSpec.configure do |config|
   end
 
   config.include ActionText::SystemTestHelper, type: :system
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
Adds should-matchers gem from Thoughbot to breeze through rspec validations.

Description fields were deleted on several finding aids on staging which caused additional errors in the JSON feed. 