### PR TITLE
Forms Sender Fix

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -193,7 +193,7 @@ class Form < MailForm::Base
       subject: get_subject[0],
       to: get_subject[1],
       cc: email,
-      from: %("#{name || default_from_name }" <#{email || default_from_email }>)
+      from: %("#{name || default_from_name } <#{email || default_from_email }>")
     }
   end
 end


### PR DESCRIPTION
Reply messages were being sent to templelibraries@gmail.com as well as the other recipients. Removing that address from the form header (inadvertently included in the first place) should prevent that in future.