### PR TITLE
MAN-1325 replace ajv with ruby json-schema gem's validate method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,6 @@ jobs:
             RAILS_ENV=test bundle exec rake db:setup
 
       - run:
-          name: Install node packages required for tests
-          command: | 
-            sudo npm install -g ajv@6.12.6
-            sudo npm install -g ajv-cli@3.3.0
-
-      - run:
           name: Install ImageMagick
           command: |
             sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ cd manifold
 bundle install
 ```
 
-* Install JSON validation tool
-
-```
-sudo apt-get -y install npm
-sudo npm install -g ajv@6.12.6
-sudo npm install -g ajv-cli@3.3.0
-```
-
 * Create database tables
 
 ```

--- a/app/schemas/alert_schema.json
+++ b/app/schemas/alert_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/blog_schema.json
+++ b/app/schemas/blog_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/building_schema.json
+++ b/app/schemas/building_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/category_schema.json
+++ b/app/schemas/category_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/collection_schema.json
+++ b/app/schemas/collection_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/event_schema.json
+++ b/app/schemas/event_schema.json
@@ -1,6 +1,6 @@
 {
   "definitions": {},
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
   "title": "The Root Schema",

--- a/app/schemas/exhibition_schema.json
+++ b/app/schemas/exhibition_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/finding_aid_schema.json
+++ b/app/schemas/finding_aid_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/group_schema.json
+++ b/app/schemas/group_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/highlight_schema.json
+++ b/app/schemas/highlight_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/person_schema.json
+++ b/app/schemas/person_schema.json
@@ -1,6 +1,6 @@
 {
   "definitions": {},
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
   "title": "The Root Schema",

--- a/app/schemas/policy_schema.json
+++ b/app/schemas/policy_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/service_schema.json
+++ b/app/schemas/service_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/space_schema.json
+++ b/app/schemas/space_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/app/schemas/webpage_schema.json
+++ b/app/schemas/webpage_schema.json
@@ -1,6 +1,6 @@
 {
 	"definitions": {},
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-06/schema#",
 	"$id": "http://example.com/root.json",
 	"type": "object",
 	"title": "The Root Schema",

--- a/spec/support/serializable_spec.rb
+++ b/spec/support/serializable_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "json-schema"
 
 RSpec.shared_examples "serializable" do
   imageClasses = ["person", "event"]
@@ -19,9 +20,8 @@ RSpec.shared_examples "serializable" do
     Tempfile.open(["serialized_#{factory_model.class.to_s.underscore.downcase}-", ".json"]) do |serialized|
       serialized.write(response.body)
       serialized.close
-      args = %W[validate -s app/schemas/#{factory_model.class.to_s.underscore.downcase}_schema.json -d #{serialized.path}]
 
-      expect(system("ajv", *args)).to be
+      expect(JSON::Validator.validate("app/schemas/#{factory_model.class.to_s.underscore.downcase}_schema.json", serialized.path)).to be
     end
   end
 

--- a/spec/support/serializer_spec.rb
+++ b/spec/support/serializer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "json-schema"
 
 RSpec.shared_examples "serializer" do
   let(:model) { described_class.to_s.split("Serializer").first.underscore.downcase.singularize.to_sym } # the class that includes the concern
@@ -11,8 +12,7 @@ RSpec.shared_examples "serializer" do
     Tempfile.open(["serialized_#{model}", ".json"]) do |tempfile|
       tempfile.write(serialized.to_json)
       tempfile.close
-      args = %W[validate -s app/schemas/#{model}_schema.json -d #{tempfile.path}]
-      expect(system("ajv", *args)).to be
+      expect(JSON::Validator.validate!("app/schemas/#{model}_schema.json", tempfile.path)).to be
     end
   end
 


### PR DESCRIPTION
- Remove ajv from project
- Incorporate JSON::Validator.validate into specs
- Downgrade custom schemas to JSON schema Draft-06 because Ruby json-schema gem does not support Draft-07 or later.