### PR TITLE
Pin base64 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "ancestry"
 gem "attr_json"
 gem "auto_strip_attributes"
 gem "aws-sdk-s3"
+gem "base64", "0.1.1"
 gem "bootsnap", require: false
 gem "bootstrap"
 gem "browser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
+    base64 (0.1.1)
     bcp47_spec (0.2.1)
     bcrypt (3.1.20)
     bigdecimal (3.1.6)
@@ -555,8 +555,7 @@ GEM
       tilt
     sax-machine (1.3.2)
     selectize-rails (0.12.6)
-    selenium-webdriver (4.17.0)
-      base64 (~> 0.2)
+    selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -663,6 +662,7 @@ DEPENDENCIES
   attr_json
   auto_strip_attributes
   aws-sdk-s3
+  base64 (= 0.1.1)
   bootsnap
   bootstrap
   brakeman


### PR DESCRIPTION
I was trying to avoid this, but nothing else seems to work.  The linode QA instance fails with this message:

The application encountered the following error: You have already activated base64 0.1.1, but your Gemfile requires base64 0.2.0. Since base64 is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports base64 as a default gem. (Gem::LoadError)

I tried a newer version of bundler, but that didn't fix the problem.  For now, pinning the gem is the easiest solution.