### PR TITLE
Man-1381 google not harvesting staff profile pages

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -51,6 +51,7 @@ SitemapGenerator::Sitemap.create do
 
   #indices
   add forms_path
+  add people_path
   add events_path
 
   #show pages

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -51,7 +51,6 @@ SitemapGenerator::Sitemap.create do
 
   #indices
   add forms_path
-  add people_path
   add events_path
 
   #show pages

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,7 @@
 Sitemap: http://library.temple.edu/sitemap.xml.gz
 
+User-agent: Googlebot
+Disallow: 
+
 User-agent: *
 Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,4 @@
 Sitemap: http://library.temple.edu/sitemap.xml.gz
 
-User-agent: Googlebot
-Disallow: /admin/
-
 User-agent: *
-Disallow: /
+Disallow: /admin/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,7 @@
 Sitemap: http://library.temple.edu/sitemap.xml.gz
 
 User-agent: Googlebot
-Disallow: 
+Disallow: /admin/
 
 User-agent: *
 Disallow: /


### PR DESCRIPTION
Engines are listing some pages, but they are also including the following message as the description: "We would like to show you a description here but the site won’t allow us." This work resets the robots directives to pre-restrictive levels, and restrictions can be added on an engine by engine basis.