### PR TITLE
BL-1410 Use Administrate application_controller's resource_params method to fix redirects

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -19,6 +19,10 @@ module Admin
     helper_method :user_editable_field?
     helper_method :current_user, :signed_in?, :is_admin?
 
+    def resource_params
+      params.require(resource_name).permit(dashboard.permitted_attributes)
+    end
+
     def edit
       super
     end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -19,10 +19,6 @@ module Admin
     helper_method :user_editable_field?
     helper_method :current_user, :signed_in?, :is_admin?
 
-    def resource_params
-      params.require(resource_name).permit(dashboard.permitted_attributes)
-    end
-
     def edit
       super
     end

--- a/app/controllers/admin/redirects_controller.rb
+++ b/app/controllers/admin/redirects_controller.rb
@@ -5,5 +5,11 @@ module Admin
     def find_resource(param)
       scoped_resource.find(param)
     end
+
+    def resource_params
+      params.require(resource_class.model_name.param_key)
+        .permit(dashboard.permitted_attributes(action_name))
+        .transform_values { |v| read_param_value(v) }
+    end
   end
 end

--- a/spec/system/admin/admin_redirects_spec.rb
+++ b/spec/system/admin/admin_redirects_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Redirects", type: :system do
+  before do
+    login_as(FactoryBot.create(:administrator))
+  end
+
+  context "Create a redirect" do
+    it "adds a space on creation" do
+      space = FactoryBot.create(:space, name: "first space")
+
+      visit admin_redirects_path
+      click_link "New redirect"
+
+      # Add a required fields
+      fill_in "redirect_legacy_path", with: "/space/1"
+      fill_in "redirect_manifold_path", with: "/library/scrc"
+      select space.name, from: "redirect_redirectable_value"
+      click_button "Create Redirect"
+
+      # Expect the new group to be created with the space
+      expect(page).to have_link(space.name)
+    end
+  end
+
+end


### PR DESCRIPTION
- Fixes inability to create redirects
- 1resource_params1 already provided by administrate's application controller which does not have problems with missing primary_key when creating a redirect
- Create spec test for this issue