### PR TITLE
MAN-1410 Redirect finding_aids index page to archives_space

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
   resources :external_link, only: [:show]
   resources :forms, only: [:index, :new, :create, :show]
   resources :file_uploads, only: [:new, :create]
-  resources :finding_aids, only: [:index, :show], path: "/finding-aids"
+  resources :finding_aids, only: [:show], path: "/finding-aids"
   resources :groups, only: [:index, :show]
   resources :highlights, only: [:index]
   resources :alerts_json, only: [:index], path: "/alerts.json"


### PR DESCRIPTION
- Redirects manifold finding-aids index page to Archives Space page
- Requires removal of trailing slash in "Path from Drupal" field.