### PR TITLE
MAN-1417-non-html-url-requests-causing-internal-errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,10 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render status: :not_found
+    respond_to do |format|
+      format.html { render "not_found", status: :not_found }
+      format.all { render plain: t("manifold.error.not_found_text_html") , status: :not_found }
+    end
   end
 
   def internal_server_error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,7 @@ en:
                                     </div>
                                     </main>
       internal_server_error_header: "There was a problem with this page."
-      internal_server_error_html: 
+      internal_server_error_html: "Please check the address for typos or <a href=\"/contact-us\">contact</a> us for further assistance."
       not_found_header: "The page you were looking for cannot be found."
       not_found_text_html: "Please check the address for typos or <a href=\"/contact-us\">contact</a> us for further assistance."
 

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -7,42 +7,42 @@ RSpec.describe ErrorsController, type: :controller do
   describe "the 404 page" do
     before { get :not_found }
     it "includes the renders the expected template" do
-      # expect(response).to render_template(:not_found)
+      expect(response).to render_template(:not_found)
     end
 
-    # it "includes the expected title" do
-    #   expect(response.body).to include(I18n.t("manifold.error.not_found_header"))
-    # end
-    # it "includes the expected text" do
-    #   expect(response.body).to include(I18n.t("manifold.error.not_found_text_html"))
-    # end
+    it "includes the expected title" do
+      expect(response.body).to include(I18n.t("manifold.error.not_found_header"))
+    end
+    it "includes the expected text" do
+      expect(response.body).to include(I18n.t("manifold.error.not_found_text_html"))
+    end
   end
 
-  # describe "the 500 page" do
-  #   before { get :internal_server_error }
-  #   it "includes the renders the expected template" do
-  #     expect(response).to render_template(:internal_server_error)
-  #   end
+  describe "the 500 page" do
+    before { get :internal_server_error }
+    it "includes the renders the expected template" do
+      expect(response).to render_template(:internal_server_error)
+    end
 
-  #   it "includes the expected title" do
-  #     expect(response.body).to include(I18n.t("manifold.error.internal_server_error_header"))
-  #   end
-  #   it "includes the expected text" do
-  #     expect(response.body).to include(I18n.t("manifold.error.internal_server_error_html"))
-  #   end
-  # end
+    it "includes the expected title" do
+      expect(response.body).to include(I18n.t("manifold.error.internal_server_error_header"))
+    end
+    it "includes the expected text" do
+      expect(response.body).to include(I18n.t("manifold.error.internal_server_error_html"))
+    end
+  end
 
-  # describe "the 503 page" do
-  #   before { get :service_unavailable }
-  #   it "includes the render of the expected template" do
-  #     expect(response).to render_template(:service_unavailable)
-  #   end
+  describe "the 503 page" do
+    before { get :service_unavailable }
+    it "includes the render of the expected template" do
+      expect(response).to render_template(:service_unavailable)
+    end
 
-  #   it "includes the expected title" do
-  #     expect(response.body).to include(I18n.t("manifold.error.service_unavailable_header"))
-  #   end
-  #   it "includes the expected text" do
-  #     expect(response.body).to include(I18n.t("manifold.error.service_unavailable_html"))
-  #   end
-  # end
+    it "includes the expected title" do
+      expect(response.body).to include(I18n.t("manifold.error.service_unavailable_header"))
+    end
+    it "includes the expected text" do
+      expect(response.body).to include(I18n.t("manifold.error.service_unavailable_html"))
+    end
+  end
 end


### PR DESCRIPTION
Bypasses template render for non-html formats:

https://app.honeybadger.io/projects/61882/faults/109925993