### PR TITLE
MAN-1373 Trap when image fails to attach to event

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -13,7 +13,7 @@ module Admin
 
     def sync
       SyncService::Events.call(force: true)
-      @message = Rails.cache.read('events_image_error')
+      @message = Rails.cache.read("events_image_error")
       flash[:notice] = @message ? @message : "Events synced"
       redirect_to admin_events_path
     end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -13,7 +13,8 @@ module Admin
 
     def sync
       SyncService::Events.call(force: true)
-      flash[:notice] = "Events synced"
+      @message = Rails.cache.read('events_image_error')
+      flash[:notice] = @message ? @message : "Events synced"
       redirect_to admin_events_path
     end
   end

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -16,21 +16,19 @@ class SyncService::Events
     @stdout = Logger.new(STDOUT)
     @eventsUrl = params.fetch(:events_url) || Rails.configuration.events_feed_url
     @force = params.fetch(:force, false)
-    # @eventsDoc = Nokogiri::XML(URI.open(@eventsUrl, { read_timeout: Rails.configuration.sync_timeout }))
-    # ruby 3.1.2 -- options hash no longer works: "no implicit conversion of Hash into String"
     @eventsDoc = Nokogiri::XML(URI.open(@eventsUrl))
     stdout_and_log("Syncing events from #{@eventsUrl}")
   end
 
   def sync
     @updated = @skipped = @errored = 0
-    read_events.each do |e|
+    read_events.each do |event|
       begin
-        @log.info(%Q(Syncing Event #{e["Title"]} on #{e["EventStartDate"]}))
-        record = record_hash(e)
+        @log.info(%Q(Syncing Event #{event["Title"]} on #{event["EventStartDate"]}))
+        record = record_hash(event)
         create_or_update_if_needed!(record)
       rescue Exception => err
-        stdout_and_log(%Q(Syncing Event #{e["Title"]} errored -  #{err.message} \n #{err.backtrace}))
+        stdout_and_log(%Q(Syncing Event #{event["Title"]} errored -  #{err.message} \n #{err.backtrace}))
         @errored += 1
       end
     end
@@ -45,6 +43,7 @@ class SyncService::Events
   end
 
   def record_hash(event)
+    # binding.pry
     {
       "guid"                => event.fetch("GUID") { raise MissingGuidException.new("No GUID found for event #{event}") },
       "title"               => event.fetch("Title", nil),
@@ -56,50 +55,62 @@ class SyncService::Events
       "registration_status" => event.fetch("RegistrationStatus", nil),
       "registration_link"   => event.fetch("ExternalRegistrationURL", nil),
       "event_url"           => event.fetch("OnlineEventHostUrl", nil),
+      "image"               => event.fetch("Image", nil),
       "start_time"          => start_time(event),
       "end_time"            => end_time(event),
-      "all_day"             => all_day(event),
-      "content_hash" => xml_hash(event)
+      "all_day"             => all_day(event)
     }
       .merge(contact(event))
       .merge(location(event))
-      .merge(event_image(event))
   end
 
-  def create_or_update_if_needed!(record_hash)
-    # If a record already exists with this content hash, then no update needed
-    if should_create_or_update(record_hash)
-      event = Event.find_by(content_hash: record_hash["content_hash"]) || Event.find_by(guid: record_hash["guid"])
-      if event
-        stdout_and_log(
-          %Q(Incoming event with title #{record_hash["title"]} matched to existing event (id = #{event.id} ) with title #{event.title}), level: :debug
-        )
-      else
-        event = Event.new
-      end
-      event.assign_attributes(record_hash.except("person", "building", "image", "path"))
-      event.person = record_hash["person"]
-      event.building = record_hash["building"]
-      event.tags = record_hash["tags"]
-      event.event_type = record_hash["event_type"]
-      event.event_url = record_hash["event_url"]
-      event.event_type += ", Online" unless event.event_url.nil?
-      unless (record_hash[:image].nil? || event.image.attached?)
-        event.image.attach(
-          io: record_hash[:image][:io],
-          filename: record_hash[:image][:filename]
-        )
-      end
-      if event.save!
-        stdout_and_log(%Q(Successfully saved record for #{record_hash["title"]}))
-        @updated += 1
-      else
-        stdout_and_log(%Q(Record not saved for #{record_hash["title"]}))
-        @updated += 1
+  def create_or_update_if_needed!(record)
+    event = Event.find_by(guid: record["guid"])
+    event = event ? event : Event.new
+    event.assign_attributes(record.except("person", "building", "image", "path"))
+    event.person = record["person"]
+    event.building = record["building"]
+    event.tags = record["tags"]
+    event.event_type = record["event_type"]
+    event.event_url = record["event_url"]
+    event.event_type += ", Online" if event.event_url.present?
+
+    if (record["image"].present?)
+      image_to_attach = event_image(record["image"])
+      event.image.attach(
+        io: image_to_attach[:image][:io],
+        filename: image_to_attach[:image][:filename]
+      )
+    else
+      event.image
+    end
+
+    if event.save!
+      stdout_and_log(%Q(Successfully saved record for #{record["title"]}))
+      @updated += 1
+    else
+      stdout_and_log(%Q(Record not saved for #{record["title"]}))
+      @updated += 1
+    end
+  end
+
+  def event_image(image_xml)
+    if image_xml
+      img = Nokogiri.XML(image_xml).xpath("//img")
+      image_path = img.attribute("src")&.value || ""
+      begin
+        {
+          image:{io: URI.open("#{image_path}"), 
+          filename: image_path.split("/thumbnail/")&.second&.split("?").first.gsub("%20", "_")},
+          alt_text: img.attribute("alt")&.value
+        }
+      rescue => e
+        stdout_and_log("Image retrieval failure for #{event["Title"]}: #{e.message}")
+        #TODO send message to admin controller about error
+        {}
       end
     else
-      stdout_and_log(%Q(Found match for content hash for #{record_hash["title"]}; skipped syncing.))
-      @skipped += 1
+      {} 
     end
   end
 
@@ -117,12 +128,6 @@ class SyncService::Events
 
   def all_day(event)
     event["EventStartTime"].include?("All day")
-  end
-
-  def xml_hash(event)
-    Digest::SHA256.hexdigest(
-      event.fetch(:xml) { raise StandardError.new("No Event XML supplied") }
-    )
   end
 
   def contact(event)
@@ -177,38 +182,6 @@ class SyncService::Events
       location_hash["external_space"] = room || nil
     end
     location_hash
-  end
-
-  def event_image(event)
-    image_xml = event.fetch("Image", nil)
-    if image_xml
-      img = Nokogiri.XML(image_xml).xpath("//img")
-      image_path = img.attribute("src")&.value || ""
-
-      {
-        image:
-          {
-            io: URI.open("#{image_path}"),
-            filename: image_path.split("/thumbnail/")&.second&.split("?").first.gsub("%20", "_")
-          },
-        alt_text: img.attribute("alt")&.value
-      }
-
-    else
-      {}
-    end
-  end
-
-  def already_exists?(record_hash)
-    Event.exists?(content_hash: record_hash["content_hash"])
-  end
-
-  def does_not_exist?(record_hash)
-    !already_exists?(record_hash)
-  end
-
-  def should_create_or_update(record_hash)
-    (does_not_exist?(record_hash) || @force)
   end
 
   def stdout_and_log(message, level: :info)

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -100,8 +100,8 @@ class SyncService::Events
       image_path = img.attribute("src")&.value || ""
       begin
         {
-          image:{io: URI.open("#{image_path}"), 
-          filename: image_path.split("/thumbnail/")&.second&.split("?").first.gsub("%20", "_")},
+          image: { io: URI.open("#{image_path}"),
+          filename: image_path.split("/thumbnail/")&.second&.split("?").first.gsub("%20", "_") },
           alt_text: img.attribute("alt")&.value
         }
       rescue => e
@@ -110,7 +110,7 @@ class SyncService::Events
         {}
       end
     else
-      {} 
+      {}
     end
   end
 

--- a/app/services/sync_service/events.rb
+++ b/app/services/sync_service/events.rb
@@ -43,8 +43,8 @@ class SyncService::Events
       result_string += "#{event.title}<br>"
     end
     if @image_failures.size > 0
-      Rails.cache.write('events_image_error', 
-                        result_string, 
+      Rails.cache.write("events_image_error",
+                        result_string,
                         expires_in: 1.hour)
     end
   end

--- a/spec/fixtures/files/badimage-event.xml
+++ b/spec/fixtures/files/badimage-event.xml
@@ -38,6 +38,6 @@
     <Highlighted>1</Highlighted>
     <Promoted>0</Promoted>
     <Weight>1</Weight>
-    <GUID>52246</GUID>
+    <GUID>52247</GUID>
   </Event>
 </Events>

--- a/spec/fixtures/files/noimage-event.xml
+++ b/spec/fixtures/files/noimage-event.xml
@@ -29,6 +29,7 @@
     <ContactName>Gretchen Sneff</ContactName>
     <ContactEmail>gsneff@temple.edu</ContactEmail>
     <ContactPhone>215-204-4724</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/file-does-not-exist.jpg?itok=QnZs4kB2&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="data powered by you October 1-5, 2018" /&gt;</Image>
     <Files></Files>
     <GAFFunding>0</GAFFunding>
     <Private>0</Private>

--- a/spec/fixtures/files/updated_single_event.xml
+++ b/spec/fixtures/files/updated_single_event.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Events>
+  <Event>
+    <Title>No-nonsense Title</Title>
+    <Path>https://events.temple.edu/data-transparency-policies-and-best-practices</Path>
+    <Description>&lt;p&gt;Join us for a webinar group viewing of Data Transparency: Policies and Best Practices, part of the 2018 ICPSR Data Fair.&lt;/p&gt;
+&lt;p&gt;Patrick Woods of the University of Michigan's Office of Research and Sponsored Projects will examine policies impacting data transparency and sharing, as well as data sharing best practices.&lt;/p&gt;
+&lt;p&gt;&lt;a href="https://guides.temple.edu/icpsr"&gt;Temple’s ICPSR representatives&lt;/a&gt; will be on hand to answer questions about Temple’s ICPSR membership, data access, and depositing options.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Register at &lt;/strong&gt; &lt;a data-saferedirecturl="https://www.google.com/url?hl=en&amp;q=https://paleystudy.temple.edu/event/4627492&amp;source=gmail&amp;ust=1537450183920000&amp;usg=AFQjCNGkoE9BVNHpkMriNKS29m4YkspMZQ" href="https://paleystudy.temple.edu/event/4627492" target="_blank"&gt;https://paleystudy.temple.edu/event/4627492&lt;/a&gt; &lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;2018 ICPSR Data Fair: “Data Powered by You”&lt;/strong&gt;&lt;/p&gt;
+&lt;p dir="ltr"&gt;Data is in the news at a dizzying rate, reminding us that our choices in collecting and sharing data are of great consequence. Join us for the Data Fair, a series of webinars taking place October 1-5, to learn from thought leaders who will delve into important topics like:&lt;/p&gt;
+&lt;ul&gt;&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data transparency&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data activism&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;data in the community&lt;/p&gt;
+&lt;/li&gt;
+&lt;li dir="ltr"&gt;
+&lt;p dir="ltr"&gt;what to do with data&lt;/p&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;p&gt;The Inter-University Consortium for Political and Social Research (ICPSR) is the world’s largest archive of digital research data. All Temple University staff, students, and faculty have access to the extensive ICPSR data holdings, and data deposit services.&lt;/p&gt;
+&lt;p&gt; &lt;/p&gt;
+</Description>
+    <Sessions></Sessions>
+    <Department>Temple University Libraries</Department>
+    <Interest>Professional Development</Interest>
+    <Type>Workshop /  Webinar</Type>
+    <EventStartDate>October 01, 2018</EventStartDate>
+    <EventStartTime>12:45 pm</EventStartTime>
+    <EventEndDate>October 01, 2018</EventEndDate>
+    <EventEndTime>2:00 pm</EventEndTime>
+    <Timestamp>&lt;span class="date-display-single"&gt;02/10/2018 &lt;span class="date-display-range"&gt;&lt;span class="date-display-start" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T12:45:00-04:00"&gt;12:45&lt;/span&gt; to &lt;span class="date-display-end" property="dc:date" datatype="xsd:dateTime" content="2018-10-02T14:00:00-04:00"&gt;14:00&lt;/span&gt;&lt;/span&gt;&lt;/span&gt;</Timestamp>
+    <TimestampStart>1538498700</TimestampStart>
+    <TimestampEnd>1538503200</TimestampEnd>
+    <Tags>library workshops</Tags>
+    <PrivateTags></PrivateTags>
+    <Campus>Main Campus</Campus>
+    <Location>Gladfelter Hall</Location>
+    <Room>Room 914</Room>
+    <Address>1115 W. Berks Street</Address>
+    <City>Philadelphia</City>
+    <State>PA</State>
+    <Zip>19122</Zip>
+    <Sponsors>Temple University Department of Criminal Justice and Temple University Libraries</Sponsors>
+    <Audience>Public</Audience>
+    <ContactName>Olivia Given Castello</ContactName>
+    <ContactEmail>olivia.castello@temple.edu</ContactEmail>
+    <ContactPhone>215-204-2613</ContactPhone>
+    <Image>&lt;img typeof="foaf:Image" src="https://events.temple.edu/sites/events/files/styles/event_thumbnail/public/events/tud29575/images/thumbnail/ICPSRDataFair2018_square_0.jpg?itok=QnZs4kB2&amp;c=8c73bf5a6d6b2a6bdd5817f6732138c4" alt="data powered by you October 1-5, 2018" /&gt;</Image>
+    <Files></Files>
+    <GAFFunding>0</GAFFunding>
+    <Private>0</Private>
+    <RegistrationStatus>Closed</RegistrationStatus>
+    <Canceled>0</Canceled>
+    <Highlighted>1</Highlighted>
+    <Promoted>0</Promoted>
+    <Weight>1</Weight>
+    <GUID>45321</GUID>
+    <LocationUnaffiliated/>
+    <AddressUnaffiliated/>
+    <StateUnaffiliated/>
+    <ZipUnaffiliated/>
+    <LocationFormattedUnaffiliated/>
+  </Event>
+</Events> 

--- a/spec/services/sync_events_spec.rb
+++ b/spec/services/sync_events_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SyncService::Events, type: :service do
       @file_cache
     end
   end
-  
+
   before(:all) do
     @sync_events = described_class.new(events_url: file_fixture("events.xml").to_path)
     @events = @sync_events.read_events
@@ -216,7 +216,7 @@ RSpec.describe SyncService::Events, type: :service do
     let(:sync_event) { described_class.new(events_url: file_fixture("single_event.xml").to_path) }
     let(:updated_sync_event) { described_class.new(events_url: file_fixture("updated_single_event.xml").to_path) }
 
-      Event.destroy_all if Event.count >= 1
+    Event.destroy_all if Event.count >= 1
 
     it "updates the record" do
       sync_event.sync
@@ -304,9 +304,9 @@ RSpec.describe SyncService::Events, type: :service do
         it "should construct message to user" do
           allow(Rails).to receive(:cache).and_return(TestFileCachingHelper.cache)
           Rails.cache.clear
-          expect(Rails.cache.exist?('events_image_error')).to be(false)
+          expect(Rails.cache.exist?("events_image_error")).to be(false)
           sync_events.sync
-          expect(Rails.cache.exist?('events_image_error')).to be(true)
+          expect(Rails.cache.exist?("events_image_error")).to be(true)
         end
       end
 


### PR DESCRIPTION
The major portion of this solution is that an event that receives the forbidden error message for an image from the university server will now still update the event. This was not how the code was previously setup. There is some refactoring of the sync code to enable this.

Any image error will now be temporarily recorded to cache and the associated event title will be displayed to the user initializing the manual sync for further review. Automatic syncs are no longer enabled, from previous work.