### PR TITLE
Google api errors

### DIFF
--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -3,7 +3,7 @@
 class LibraryHoursController < ApplicationController
   def index
     hours = Google::SheetsConnector.call(feature: "hours")
-  
+
     if hours.present?
       render(Google::HoursComponent.new(hours:, date: params[:date]))
     else

--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -2,11 +2,7 @@
 
 class LibraryHoursController < ApplicationController
   def index
-    begin
-      hours = Google::SheetsConnector.call(feature: "hours")
-    rescue Google::Apis::ClientError
-      hours = nil
-    end
+    hours = Google::SheetsConnector.call(feature: "hours")
   
     if hours.present?
       render(Google::HoursComponent.new(hours:, date: params[:date]))

--- a/app/controllers/library_hours_controller.rb
+++ b/app/controllers/library_hours_controller.rb
@@ -2,7 +2,12 @@
 
 class LibraryHoursController < ApplicationController
   def index
-    hours = Google::SheetsConnector.call(feature: "hours")
+    begin
+      hours = Google::SheetsConnector.call(feature: "hours")
+    rescue Google::Apis::ClientError
+      hours = nil
+    end
+  
     if hours.present?
       render(Google::HoursComponent.new(hours:, date: params[:date]))
     else

--- a/app/controllers/webpages_controller.rb
+++ b/app/controllers/webpages_controller.rb
@@ -69,7 +69,12 @@ class WebpagesController < ApplicationController
   end
 
   def home
-    @charles_hours = Google::SheetsConnector.call(feature: "hours", scope: "charles")
+    begin
+      @charles_hours = Google::SheetsConnector.call(feature: "hours", scope: "charles")
+    rescue Google::Apis::ClientError
+      @charles_hours = nil
+    end
+
     if @charles_hours.present?
       @hours = Google::TodaysHours.new(hours: @charles_hours)
     else

--- a/app/services/google/sheets_connector.rb
+++ b/app/services/google/sheets_connector.rb
@@ -28,14 +28,18 @@ module Google
     end
 
     def call
-      if @feature == "hours"
-        if @scope.present?
-          response = @service.batch_get_spreadsheet_values(@spreadsheet_id, ranges: ["A2:A", "#{@cells}"], major_dimension: "ROWS")
+      begin
+        if @feature == "hours"
+          if @scope.present?
+            response = @service.batch_get_spreadsheet_values(@spreadsheet_id, ranges: ["A2:A", "#{@cells}"], major_dimension: "ROWS")
+          else
+            response = @service.get_spreadsheet_values(@spreadsheet_id, "#{@cells}")
+          end
         else
-          response = @service.get_spreadsheet_values(@spreadsheet_id, "#{@cells}")
+          response = @service.get_spreadsheet_values(@spreadsheet_id, @cells)
         end
-      else
-        response = @service.get_spreadsheet_values(@spreadsheet_id, @cells)
+      rescue => e
+        nil
       end
     end
 

--- a/app/views/application/_todays_date.html.erb
+++ b/app/views/application/_todays_date.html.erb
@@ -1,2 +1,2 @@
-<span class="d-block"><%= t("manifold.header.todays_hours") %> | <%= render @hours %></span>
+<span class="d-block"><%= t("manifold.header.todays_hours") %> | <%= @hours.present? ? (render @hours) : " <not available>" %></span>
 <%= link_to t("manifold.header.all_hours"), hours_path %> >

--- a/app/views/application/_todays_date.html.erb
+++ b/app/views/application/_todays_date.html.erb
@@ -1,2 +1,4 @@
-<span class="d-block"><%= t("manifold.header.todays_hours") %> | <%= @hours.present? ? (render @hours) : " <not available>" %></span>
+<% if @hours.present? %>
+  <span class="d-block"><%= t("manifold.header.todays_hours") %> | <%= render @hours %></span>
+<% end %>
 <%= link_to t("manifold.header.all_hours"), hours_path %> >

--- a/spec/controllers/webpages_controller_spec.rb
+++ b/spec/controllers/webpages_controller_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe WebpagesController, type: :controller do
         expect(response).to be_successful
       end
     end
+
+    it "handles errors from google api" do
+      VCR.use_cassette('google_api_error') do
+        get :home
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "GET #scrc" do

--- a/spec/controllers/webpages_controller_spec.rb
+++ b/spec/controllers/webpages_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe WebpagesController, type: :controller do
     end
 
     it "handles errors from google api" do
-      VCR.use_cassette('google_api_error') do
+      VCR.use_cassette("google_api_error") do
         get :home
         expect(response).to be_successful
       end

--- a/spec/fixtures/vcr_cassettes/google_api_error.yml
+++ b/spec/fixtures/vcr_cassettes/google_api_error.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sheets.googleapis.com/v4/spreadsheets/1IXyE2EgREGvxpVBz_qcDlQovQ-w3BJOgUCfwz8bBtqI/values:batchGet?key=<gsheets_key>&majorDimension=ROWS&ranges=B2:B
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - unknown/0.0.0 google-apis-sheets_v4/0.35.0 Mac OS X/14.5 (gzip)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 04 Sep 2024 12:48:24 GMT
+      X-Goog-Api-Client:
+      - gl-ruby/3.3.0 gdcl/1.35.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: "Invalid request"
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 04 Sep 2024 12:48:24 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      X-L2-Request-Path:
+      - l2-managed-6
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {"error": "Invalid request}
+  recorded_at: Wed, 04 Sep 2024 12:48:24 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
Addresses issue of homepage not rendering if todays_hours widget gets an error response from google api.

Adds rescues to service object and controller to allow flow of render to proceed without google data

Does not display widget if errors from google
