### PR TITLE
MAN-1437 NoMethodError: undefined method `label' for nil

### DIFF
--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -48,7 +48,7 @@ class Exhibition < ApplicationRecord
     {
       startDate: start_date,
       endDate: end_date,
-      location: {
+      location: space.present? ? {
         "@type" => "Place",
         name: space.label,
         address: {
@@ -56,7 +56,7 @@ class Exhibition < ApplicationRecord
           streetAddress: space.building.address1,
           addressLocality: space.building.address2
         }
-      }
+      } : nil
     }
   end
 end

--- a/spec/models/exhibition_spec.rb
+++ b/spec/models/exhibition_spec.rb
@@ -22,6 +22,59 @@ RSpec.describe Exhibition, type: :model do
     end
   end
 
+  describe "#additional_schema_dot_org_attributes" do
+    let(:building) { double(address1: "123 Main St", address2: "Suite 100") }
+    let(:space) { double(label: "Conference Room A", building: building) }
+    let(:start_date) { Date.new(2024, 1, 1) }
+    let(:end_date) { Date.new(2024, 12, 31) }
+
+    before do
+      allow(subject).to receive(:start_date).and_return(start_date)
+      allow(subject).to receive(:end_date).and_return(end_date)
+    end
+
+    context "when space is present" do
+
+      before do
+        allow(subject).to receive(:space).and_return(space)
+      end
+
+      it "returns the correct schema.org attributes" do
+        expected_output = {
+          startDate: start_date,
+          endDate: end_date,
+          location: {
+            "@type" => "Place",
+            name: space.label,
+            address: {
+              "@type" => "PostalAddress",
+              streetAddress: building.address1,
+              addressLocality: building.address2
+            }
+          }
+      }
+
+      expect(subject.additional_schema_dot_org_attributes).to eq(expected_output)
+      end
+    end
+
+    context "when space is nil" do
+      before do
+        allow(subject).to receive(:space).and_return(nil)
+      end
+
+      it "returns nil for location" do
+        expected_output = {
+          startDate: start_date,
+          endDate: end_date,
+          location: nil
+        }
+
+        expect(subject.additional_schema_dot_org_attributes).to eq(expected_output)
+      end
+    end
+  end
+
   it_behaves_like "categorizable"
   it_behaves_like "imageables"
 


### PR DESCRIPTION
It looks like space is an optional field for exhibitions, but the additional_schema_dot_org_attributes method is expecting it to be there.  This refactors that method to handle nil spaces and adds tests to the method for both contexts.