### PR TITLE
Adds net-imap to documentation

### DIFF
--- a/Documentation/essential_packages.txt
+++ b/Documentation/essential_packages.txt
@@ -1,1 +1,2 @@
 cgi
+net-imap


### PR DESCRIPTION
Required by Mail, Mail is at highest version 2.8.1. Need to wait for update to Mail, possibly ruby >= 3.4