### PR TITLE
No ruby version in Gemfile

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [ "3.4.3" ]
+        ruby: [ "3.4" ]
 
     steps:
       - name: Checkout code
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-          ruby: ["3.4.3"]
+          ruby: ["3.4"]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov/app.lcov

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -75,7 +75,7 @@ jobs:
         run: bundle exec rspec spec
 
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v1
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov/app.lcov

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.4.3"
-
 gem "rails", "~> 7.2"
 gem "action-draft"
 gem "active_storage_validations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -849,8 +849,5 @@ DEPENDENCIES
   webmock
   yaml_db
 
-RUBY VERSION
-   ruby 3.4.3p32
-
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION
We cannot put a ruby version in the Gemfile.  The ruby version that we use comes from the base docker image.  If a version is put in the Gemfile, it would have to be updated every time the base image is changed because it breaks the build if the two versions are not the same.  It is cleaner to just let the ruby version come from the base image.