### PR TITLE
DB Seed per deploy

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -43,6 +43,7 @@ RUN apk add -U --no-cache \
     if [ "${RAILS_ENV}" = "production" ]; then rm -rf tmp/*; fi && \
     if [ "${RAILS_ENV}" = "production" ]; then apk del build-dependencies; fi && \
     rails sync:todays_hours && \
+    rails db:seed && \
     rm -rf /var/cache/apk/ && \
     rm -rf /usr/local/share/.cache/yarn && \
     chown nobody -R /app/tmp && \


### PR DESCRIPTION
Dockerfile now runs db:seed. 

Only conditional seeds should be used, i.e., unless ModelName.exists?(slug: slug-name)

See current seed file for example. This will make it easier to deploy new/updated features that require a model instance to get started.