### PR TITLE
Revert HELM_VERSION_PROD change and export VERSION=$CI_COMMIT_TAG.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,10 +115,11 @@ prod_deploy:
   only:
     - tags
   script:
+    - export VERSION=$CI_COMMIT_TAG
     - helm pull oci://$HARBOR/tulibraries/charts/manifold --version $HELM_VERSION_PROD --untar
     - |
       helm upgrade manifold oci://$HARBOR/tulibraries/charts/manifold \
-        --version $CI_COMMIT_TAG \
+        --version $HELM_VERSION_PROD \
         --history-max=5 --namespace=manifold-prod \
         --values manifold/values-prod.yaml \
         --set image.repository=$IMAGE:$CI_COMMIT_TAG \


### PR DESCRIPTION
I was wrong about there being two uses of --version in helm.

This change was tested successfully with a tul_cob deployment.