### PR TITLE
MAN-1544-staff-directory-search-broken-on-mobile

### DIFF
--- a/app/controllers/persons_controller.rb
+++ b/app/controllers/persons_controller.rb
@@ -18,17 +18,17 @@ class PersonsController < ApplicationController
     @subjects = get_specialty_filter_values(all)
     @departments = get_department_filter_values(all)
 
-    if params[:department].present?
-      d = Group.friendly.find(params[:department])
+    if (params[:department] || params[:m_department]).present?
+      d = Group.friendly.find(params[:department] || params[:m_department])
       if d.present?
         key = "Department"
         value = d.label
       end
     end
 
-    if params[:specialty].present?
+    if (params[:specialty] || params[:m_subject]).present?
       key = "Specialty"
-      value = params[:specialty]
+      value = params[:specialty] || params[:m_subject]
     end
 
     if params[:search].present?
@@ -66,17 +66,20 @@ class PersonsController < ApplicationController
   end
 
   def get_persons
+    department = params[:department] || params[:m_department]
+    specialty = params[:specialty] || params[:m_subject]
+
     if params[:search].present?
       @filtered_persons = Person.search(params[:search])
-    elsif (params[:specialists].present? && params[:specialists] == "true") && params[:department].nil?
+    elsif (params[:specialists].present? && params[:specialists] == "true") && department.nil?
       @filtered_persons = Person.is_specialist
-    elsif (params[:specialists].present? && params[:specialists] == "true") && params[:department].present?
-      @filtered_persons = Person.in_department(params[:department]).is_specialist
+    elsif (params[:specialists].present? && params[:specialists] == "true") && department.present?
+      @filtered_persons = Person.in_department(department).is_specialist
       @specialist_search = true
-    elsif params[:specialty].present?
-      @filtered_persons = Person.with_specialty(params[:specialty])
-    elsif params[:department]
-      @filtered_persons = Person.in_department(params[:department])
+    elsif specialty.present?
+      @filtered_persons = Person.with_specialty(specialty)
+    elsif department
+      @filtered_persons = Person.in_department(department)
     else
       @filtered_persons = Person.all
     end

--- a/app/views/persons/_mobile-menu.html.erb
+++ b/app/views/persons/_mobile-menu.html.erb
@@ -14,17 +14,19 @@
       <div class="navbar-nav"> 
            <div class="filters row pb-3 px-0 mb-4">
             <div class="col-12 d-inline-block mt-0">
-            <%= form_tag(person_search_path, method: "POST", class: "d-inline-block mr-3 mt-0", id: "m-people-search") do %>
-              <%= label_tag(:search, "search staff directory by name or title", :class=>"element-invisible") %>
-              <%= text_field_tag(:search, nil, class: "form-control d-inline-block search-icon", 
-                        placeholder: "search staff directory by name or title",
-                        results: "0"
-                        ) %>
+            <%= form_with(url: people_path, method: :get,
+                          data: { controller: "search-form",
+                                  action: "input->search-form#search",
+                                  turbo_frame: "people",
+                                  turbo_action: "advance" },
+                          id: "m-people-search") do |form| %>
+              <%= form.label :search, "search staff directory by name or title", class: "element-invisible" %>
+              <%= form.text_field :search, placeholder: "search staff directory by name or title", class: "form-control d-inline-block search-icon" %>
             <% end %>
 
             <%= form_with url: people_path, method: "GET", id: "m-people-filters", class: "d-inline-block" do |f| %>
-              <%= f.select :m_department, @departments, include_blank: "filter by department" if @departments.present? %>
-              <%= f.select :m_subject, @subjects, include_blank: "filter by specialty" if @subjects.present? %>
+              <%= f.select :m_department, @departments, { include_blank: "filter by department" }, data: { action: "change->people#departments" } if @departments.present? %>
+              <%= f.select :m_subject, @subjects, { include_blank: "filter by specialty" }, data: { action: "change->people#specialties" } if @subjects.present? %>
             <% end %>
             </div>
             <div class="col-12 mt-3 mb-0 ml-3 filter-links">

--- a/app/views/persons/index.html.erb
+++ b/app/views/persons/index.html.erb
@@ -1,6 +1,7 @@
+<div data-controller="people">
 <%= render "mobile-menu" %>
 
-<div class="container-xl staff-index" data-controller="people">
+<div class="container-xl staff-index">
 
   <h1><%= title "Staff Directory" %></h1>
 
@@ -60,4 +61,5 @@
     
   </div>
 
+</div>
 </div>

--- a/spec/controllers/persons_controller_spec.rb
+++ b/spec/controllers/persons_controller_spec.rb
@@ -24,6 +24,35 @@ RSpec.describe PersonsController, type: :controller do
       expect(response.header["Content-Type"]).to include "json"
     end
 
+    context "filtering by department" do
+      let(:group) { FactoryBot.create(:group) }
+
+      it "filters via desktop department param" do
+        get :index, params: { department: group.slug }
+        expect(assigns(:filtered_persons)).to include(*group.persons)
+      end
+
+      it "filters via mobile m_department param" do
+        get :index, params: { m_department: group.slug }
+        expect(assigns(:filtered_persons)).to include(*group.persons)
+      end
+    end
+
+    context "filtering by specialty" do
+      let(:subject) { FactoryBot.create(:subject) }
+      let!(:person_with_subject) { FactoryBot.create(:person, subjects: [subject]) }
+
+      it "filters via desktop specialty param" do
+        get :index, params: { specialty: subject.name }
+        expect(assigns(:filtered_persons)).to include(person_with_subject)
+      end
+
+      it "filters via mobile m_subject param" do
+        get :index, params: { m_subject: subject.name }
+        expect(assigns(:filtered_persons)).to include(person_with_subject)
+      end
+    end
+
   end
 
   describe "GET #show" do


### PR DESCRIPTION
Mobile filter forms were missing the turbo frame and action wiring present on the desktop forms. The m_department and m_subject params submitted by the mobile selects weren't being handled by the controller, so filtering silently did nothing — extended PersonsController to accept both the mobile and desktop param names. The mobile menu was also rendered outside the data-controller="people" element, which prevented the Stimulus change actions from firing at all. Wrapped both in a shared controller scope to fix that. Added controller specs covering both desktop and mobile filter params.