### PR TITLE
MAN-1551-honeybadger-htt-party-unsafe-uri-error

### DIFF
--- a/app/services/microsoft_graph/client.rb
+++ b/app/services/microsoft_graph/client.rb
@@ -56,7 +56,7 @@ module MicrosoftGraph
       def access_token
         @access_token ||= begin
           auth_url = "https://login.microsoftonline.com/#{@tenant_id}/oauth2/v2.0/token"
-          response = self.class.post(
+          response = HTTParty.post(
             auth_url,
             body: {
               grant_type: "client_credentials",

--- a/spec/services/microsoft_excel_service_spec.rb
+++ b/spec/services/microsoft_excel_service_spec.rb
@@ -95,6 +95,21 @@ RSpec.describe MicrosoftExcelService do
     end
   end
 
+  describe "#access_token" do
+    it "posts to the Microsoft login URL without raising HTTParty::UnsafeURIError" do
+      client = MicrosoftGraph::Client.allocate
+      client.instance_variable_set(:@tenant_id, "tenant123")
+      client.instance_variable_set(:@client_id, "client123")
+      client.instance_variable_set(:@client_secret, "secret123")
+
+      stub_request(:post, "https://login.microsoftonline.com/tenant123/oauth2/v2.0/token")
+        .to_return(status: 200, body: { access_token: "test_token" }.to_json)
+
+      expect { client.send(:access_token) }.not_to raise_error
+      expect(client.send(:access_token)).to eq("test_token")
+    end
+  end
+
   describe "#workbook_item_path" do
     it "prefers drive_id when present" do
       client = MicrosoftGraph::Client.allocate


### PR DESCRIPTION
The Microsoft Graph client was posting to the OAuth token endpoint (login.microsoftonline.com) using self.class.post, which inherits the HTTParty base_uri of graph.microsoft.com. HTTParty's URI safety check raises UnsafeURIError when the request host doesn't match the configured base host. Fixed by using recommended (https://github.com/jnunemaker/httparty/tree/main/docs) HTTParty.post directly for the token request, which has no base URI constraint. Added a spec to microsoft_excel_service_spec.rb covering the token fetch to prevent regression