### PR TITLE
MAN-1542-improve-manifold-alerts

### DIFF
--- a/app/dashboards/alert_dashboard.rb
+++ b/app/dashboards/alert_dashboard.rb
@@ -13,6 +13,7 @@ class AlertDashboard < Administrate::BaseDashboard
     id: Field::Number,
     scroll_text: Field::String,
     link: Field::String,
+    link_text: Field::String,
     description:  DescriptionField,
     published: Field::Boolean,
     for_header: Field::Boolean,
@@ -30,6 +31,7 @@ class AlertDashboard < Administrate::BaseDashboard
     :for_header,
     :scroll_text,
     :link,
+    :link_text,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -37,6 +39,7 @@ class AlertDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :scroll_text,
     :link,
+    :link_text,
     :description,
     :published,
     :for_header,
@@ -50,6 +53,7 @@ class AlertDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :scroll_text,
     :link,
+    :link_text,
     :description,
     :published,
     :for_header,

--- a/app/schemas/alert_schema.json
+++ b/app/schemas/alert_schema.json
@@ -47,6 +47,7 @@
 					"required": [
 						            "scroll_text",
                         "link",
+												"link_text",
                         "published",
 						            "description"
 					],
@@ -71,6 +72,16 @@
 							],
 							"pattern": "^(.*)$"
                         },
+						"link_text": {
+							"$id": "#/properties/data/properties/attributes/properties/link_text",
+							"type": "string",
+							"title": "The Label Schema",
+							"default": "",
+							"examples": [
+								"The Library Collection"
+							],
+							"pattern": "^(.*)$"
+                        },
 						"published": {
 							"$id": "#/properties/data/properties/attributes/properties/published",
 							"type": "boolean",
@@ -87,8 +98,7 @@
 							"default": "",
 							"examples": [
 								"This is the description of the collection"
-							],
-							"pattern": "^(.*)$"
+							]
 						}
 					}
 				},

--- a/app/serializers/alert_serializer.rb
+++ b/app/serializers/alert_serializer.rb
@@ -3,5 +3,5 @@
 class AlertSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :published, :scroll_text, :link, :for_header, :description, :updated_at
+  attributes :published, :scroll_text, :link, :link_text, :for_header, :description, :updated_at
 end

--- a/app/views/application/_header_navbar.html.erb
+++ b/app/views/application/_header_navbar.html.erb
@@ -44,7 +44,11 @@
         <p class="mb-0">
         <% @alert.each do |alert| %>
           <% unless alert.link.blank? %>
-            <%= alert.scroll_text %> <%= link_to t("manifold.default.application.header_navbar.scroll_text"), alert.link %>
+            <% if alert.link_text.present? %>
+              <%= alert.scroll_text %> <%= link_to alert.link_text, alert.link %>
+            <% else %>
+              <%= alert.scroll_text %> <%= link_to t("manifold.default.application.header_navbar.scroll_text"), alert.link %>
+            <% end %>
           <% else %>
             <%= alert.scroll_text %>
           <% end %>

--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -7,7 +7,7 @@
     <% if [:slug].include? field.attribute %>
       <p class="h-one-half"></p>
     <% end %>
-    <% if [:title, :name].include? field.attribute %>
+    <% if [:title, :name, :link].include? field.attribute %>
       <p class="h-one-half"></p>
     <% end %>
   <% end %>
@@ -31,6 +31,9 @@
         <% end %>
         <% if field.attribute == :tutorial_path %>
           <p><%= t("manifold.default.fields.string.tutorial_path") %></p>
+        <% end %>
+        <% if field.attribute == :link %>
+          <p><%= t("manifold.default.fields.string.link") %></p>
         <% end %>
       <% end %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
           slugs: "Slugs are used to set the browser path and in the code to link resources together. Edit with extreme caution. Read more in [<a href=\"https://tulibdev.atlassian.net/wiki/spaces/LWR/pages/1047166982/Slugs\">Confluence</a>]</p>"
           renaming: "When renaming, completely remove the slug field below. A new slug will be generated reflecting the new name/title. If you do not want the slug (browser path) to change, do not touch the existing slug."
           tutorial_path: "Only specify the portion of the url after https://alt.library.temple.edu/tutorials/"
+          link: "Include http:// or https:// and the full domain in the link."
       application:
         building_hours:
           title: Weekly Hours

--- a/db/migrate/20260630125439_add_custom_text_to_alert_link.rb
+++ b/db/migrate/20260630125439_add_custom_text_to_alert_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCustomTextToAlertLink < ActiveRecord::Migration[8.1]
   def change
     add_column :alerts, :link_text, :string

--- a/db/migrate/20260630125439_add_custom_text_to_alert_link.rb
+++ b/db/migrate/20260630125439_add_custom_text_to_alert_link.rb
@@ -1,0 +1,5 @@
+class AddCustomTextToAlertLink < ActiveRecord::Migration[8.1]
+  def change
+    add_column :alerts, :link_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_125439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -98,6 +98,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_000001) do
     t.datetime "created_at", precision: nil, null: false
     t.boolean "for_header"
     t.string "link"
+    t.string "link_text"
     t.boolean "published"
     t.string "scroll_text"
     t.datetime "updated_at", precision: nil, null: false

--- a/spec/factories/alerts.rb
+++ b/spec/factories/alerts.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :alert do
     scroll_text { "This is an alert" }
     link { "http://library.temple.edu" }
+    link_text { "" }
     description { ActionText::Content.new("Hello World") }
     published { true }
 

--- a/spec/views/application/header_navbar_html_spec.rb
+++ b/spec/views/application/header_navbar_html_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "application/_header_navbar.html.erb", type: :view do
+  before do
+    assign(:alert, alerts)
+    assign(:header_search, nil)
+    assign(:mobile_search, nil)
+
+    allow(view).to receive(:action_name).and_return("home")
+
+    stub_template "application/_todays_date.html.erb" => ""
+    stub_template "application/_main-menu.html.erb" => ""
+    stub_template "application/_mobile-nav.html.erb" => ""
+  end
+
+  context "when the alert has custom link text" do
+    let(:alerts) do
+      [FactoryBot.build(:alert, scroll_text: "Library Search notice.", link: "https://librarysearch.temple.edu", link_text: "Read the outage notice")]
+    end
+
+    it "renders the custom link text" do
+      render partial: "application/header_navbar"
+
+      expect(rendered).to include("Library Search notice.")
+      expect(rendered).to include("Read the outage notice")
+      expect(rendered).to include(%(href="https://librarysearch.temple.edu"))
+      expect(rendered).not_to include(I18n.t("manifold.default.application.header_navbar.scroll_text"))
+    end
+  end
+
+  context "when the alert link text is blank" do
+    let(:alerts) do
+      [FactoryBot.build(:alert, scroll_text: "Library Search notice.", link: "https://librarysearch.temple.edu", link_text: "")]
+    end
+
+    it "renders the fallback link text" do
+      render partial: "application/header_navbar"
+
+      expect(rendered).to include("Library Search notice.")
+      expect(rendered).to include(I18n.t("manifold.default.application.header_navbar.scroll_text"))
+      expect(rendered).to include(%(href="https://librarysearch.temple.edu"))
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for custom alert link text so header alerts can display author-defined copy instead of always using the default fallback text. It includes the new link_text field in the alert schema and serializer output, exposes it in the admin/dashboard flow, and updates the header alert rendering to use link_text when present while preserving the existing fallback text when it is blank. It also adds test coverage for both the custom-text and fallback behaviors.