### PR TITLE
Fixes build error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,6 +98,8 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :microsoft_graph_mailer
 
-  Rails.application.routes.default_url_options[:host] = ENV["MANIFOLD_FQDN"]
-  Rails.application.routes.default_url_options[:protocol] = "https"
+  if (manifold_fqdn = ENV["MANIFOLD_FQDN"].presence)
+    Rails.application.routes.default_url_options[:host] = manifold_fqdn
+    Rails.application.routes.default_url_options[:protocol] = "https"
+  end
 end


### PR DESCRIPTION
Fixes ' ArgumentError: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true (ArgumentError)'