### PR TITLE
MAN-1568-display-full-event-title-on-events-page

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -18,7 +18,8 @@
     </div>
 
     <div class="col-12 col-lg-6 event-info">
-      <h1 class="page-title"><%= title @event.title %></h1>
+      <% title @event.title %>
+      <h1 class="page-title"><%= @event.title %></h1>
       <p class="fs-5"><%= @event.get_date %> | <%= @event.set_times %></p>
       <%= @event.description %>
     </div>


### PR DESCRIPTION
The meta-tags gem char limit needs to be got around for display purposes but kept for SEO. This sets what the gem expects, but for display purposes, the user will see the untruncated title.