### PR TITLE
MAN-1553-switch-events-harvest-source-to-lib-cal

### DIFF
--- a/app/services/sync_service/libcal_events.rb
+++ b/app/services/sync_service/libcal_events.rb
@@ -5,7 +5,7 @@ require "open-uri"
 require "resolv-replace"
 require "logger"
 require "net/http"
-require "open3"
+require "socket"
 require "tempfile"
 require "digest"
 
@@ -14,6 +14,20 @@ class SyncService::LibcalEvents
   class UnexpectedResponseShapeException < StandardError; end
   class MissingAccessTokenConfigurationException < StandardError; end
   class MissingEventIdException < StandardError; end
+  class ImageDownloadException < StandardError; end
+
+  # The image CDN advertises AAAA records we cannot route to, so connect over the
+  # A record while leaving the Host header and TLS SNI/cert check on the hostname.
+  class Ipv4ConnectionAdapter < HTTParty::ConnectionAdapter
+    def connection
+      http = super
+      ipv4 = Addrinfo.getaddrinfo(uri.host, nil, Socket::AF_INET, :STREAM).first&.ip_address
+      raise ImageDownloadException, "No IPv4 address for #{uri.host}" if ipv4.blank?
+
+      http.ipaddr = ipv4
+      http
+    end
+  end
 
   def self.call(events_url: nil, events_urls: nil, event_ids: nil, access_token: nil, force: false, response_body: nil)
     new(events_url:, events_urls:, event_ids:, access_token:, force:, response_body:).sync
@@ -514,20 +528,25 @@ class SyncService::LibcalEvents
     end
 
     def download_image_over_ipv4(image_url, event)
-      raise "Refusing to download non-HTTP image URL: #{image_url}" unless image_url.to_s.match?(%r{\Ahttps?://}i)
+      unless image_url.to_s.match?(%r{\Ahttps?://}i)
+        raise ImageDownloadException, "Refusing to download non-HTTP image URL: #{image_url}"
+      end
+
+      response = HTTParty.get(
+        image_url,
+        connection_adapter: Ipv4ConnectionAdapter,
+        follow_redirects: true,
+        open_timeout: 10,
+        read_timeout: 30
+      )
+
+      unless response.success?
+        raise ImageDownloadException, "Image request for #{image_url} returned #{response.code}"
+      end
 
       file = Tempfile.new(["libcal-event-image-#{event.guid}-", File.extname(URI.parse(image_url).path)])
       file.binmode
-
-      # Force IPv4 (the image CDN's IPv6 is unreliable). Uses Open3 with array args
-      # and a "--" terminator so the URL can never be interpreted as a curl option.
-      image_data, error, status = Open3.capture3(
-        "curl", "-4", "--fail", "--silent", "--show-error", "--location", "--", image_url,
-        binmode: true
-      )
-      raise "curl failed for #{image_url}: #{error}" unless status.success?
-
-      file.write(image_data)
+      file.write(response.body)
       file.rewind
       file
     end

--- a/spec/services/sync_service/libcal_events_spec.rb
+++ b/spec/services/sync_service/libcal_events_spec.rb
@@ -30,25 +30,47 @@ RSpec.describe SyncService::LibcalEvents, type: :service do
     Rails.configuration.libcal_token_url = original_token_url
   end
 
-  describe "oversized images" do
-    let(:image_body) { [{ "id" => 555, "title" => "Big Image Event", "featured_image" => "https://example.com/huge.png" }].to_json }
+  describe "event images" do
+    let(:image_url) { "https://example.com/event.png" }
+    let(:image_body) { [{ "id" => 555, "title" => "Image Event", "featured_image" => image_url }].to_json }
+    # A one-pixel PNG, so ActiveStorage has real image bytes to analyze.
+    let(:png) { Base64.decode64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==") }
 
-    it "saves the event without the image instead of dropping the whole record" do
-      service = described_class.new(response_body: image_body)
+    before do
+      # The IPv4 adapter resolves the host itself, and WebMock does not intercept DNS.
+      allow(Addrinfo).to receive(:getaddrinfo)
+        .with("example.com", nil, Socket::AF_INET, :STREAM)
+        .and_return([Addrinfo.tcp("93.184.216.34", 443)])
+    end
 
-      oversized = Tempfile.new(["huge", ".png"])
-      oversized.binmode
-      oversized.write("x" * (I18n.t("manifold.default.image_file_size_limit").kilobyte + 1))
-      oversized.rewind
-      allow(service).to receive(:download_image_over_ipv4).and_return(oversized)
+    it "downloads the image over IPv4 and attaches it" do
+      stub_request(:get, image_url).to_return(status: 200, body: png, headers: { "Content-Type" => "image/png" })
 
-      expect { service.sync }.to change(Event, :count).by(1)
+      described_class.call(response_body: image_body)
+
+      event = Event.find_by(guid: "555")
+      expect(event.image).to be_attached
+    end
+
+    it "saves the event without the image when the download fails" do
+      stub_request(:get, image_url).to_return(status: 404)
+
+      expect { described_class.call(response_body: image_body) }.to change(Event, :count).by(1)
 
       event = Event.find_by(guid: "555")
       expect(event).to be_present
       expect(event.image).not_to be_attached
-    ensure
-      oversized&.close!
+    end
+
+    it "saves the event without the image instead of dropping the whole record when oversized" do
+      oversized = "x" * (I18n.t("manifold.default.image_file_size_limit").kilobyte + 1)
+      stub_request(:get, image_url).to_return(status: 200, body: oversized, headers: { "Content-Type" => "image/png" })
+
+      expect { described_class.call(response_body: image_body) }.to change(Event, :count).by(1)
+
+      event = Event.find_by(guid: "555")
+      expect(event).to be_present
+      expect(event.image).not_to be_attached
     end
   end
 


### PR DESCRIPTION
Curl available locally but not part of image; replaces with httparty and updates tests