### PR TITLE
MAN-1553-switch-events-harvest-source-to-lib-cal

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -11,15 +11,32 @@ module Admin
       )
     end
 
+    # Flash is stored in the session cookie, which Rack caps at 4kb -- so only ever
+    # name the first few failures and point at the log for the rest.
+    LISTED_IMAGE_FAILURES = 5
+
     def sync
       SyncService::LibcalEvents.call
-      @message = Rails.cache.read("events_image_error")
-      flash[:notice] = @message ? @message : "Events synced"
+      flash[:notice] = sync_message(Rails.cache.read("events_image_error"))
       redirect_to admin_events_path
     end
 
     def valid_action?(name, resource = resource_class)
       %w[new destroy].exclude?(name.to_s) && super
     end
+
+    private
+
+      def sync_message(failed_titles)
+        return "Events synced" if failed_titles.blank?
+
+        listed = failed_titles.first(LISTED_IMAGE_FAILURES)
+        remaining = failed_titles.size - listed.size
+        names = listed.join(", ")
+        names += ", and #{remaining} more (see log/sync-libcal-event.log)" if remaining.positive?
+
+        "Events synced, but #{failed_titles.size} " \
+          "#{'image'.pluralize(failed_titles.size)} could not be retrieved from LibCal: #{names}"
+      end
   end
 end

--- a/app/services/sync_service/libcal_events.rb
+++ b/app/services/sync_service/libcal_events.rb
@@ -129,16 +129,11 @@ class SyncService::LibcalEvents
   end
 
   def send_image_failures_to_cache
-    result_string = "LibCal image retrieval failure. Please check:<br><br>"
-    @image_failures.each do |event|
-      result_string += "#{event.title}<br>"
-    end
+    return if @image_failures.empty?
 
-    if @image_failures.size > 0
-      Rails.cache.write("events_image_error",
-                        result_string,
-                        expires_in: 1.hour)
-    end
+    Rails.cache.write("events_image_error",
+                      @image_failures.map(&:title),
+                      expires_in: 1.hour)
   end
 
   private

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Admin::EventsController, type: :controller do
       post :sync
       expect(::SyncService::LibcalEvents).to have_received(:call)
       expect(response).to redirect_to(admin_events_path)
+      expect(flash[:notice]).to eq("Events synced")
+    end
+
+    it "summarizes image failures without overflowing the 4kb session cookie" do
+      # The test env uses a null cache store, so stub the read the sync action does.
+      titles = Array.new(40) { |i| "A Fairly Long Event Title That Eats Cookie Bytes #{i}" }
+      allow(Rails.cache).to receive(:read).with("events_image_error").and_return(titles)
+
+      post :sync
+
+      expect(response).to redirect_to(admin_events_path)
+      expect(flash[:notice]).to include("40 images could not be retrieved")
+      expect(flash[:notice]).to include("and 35 more")
+      expect(flash[:notice].bytesize).to be < 1_000
     end
   end
 end

--- a/spec/services/sync_service/libcal_events_spec.rb
+++ b/spec/services/sync_service/libcal_events_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe SyncService::LibcalEvents, type: :service do
       expect(event).to be_present
       expect(event.image).not_to be_attached
     end
+
+    it "caches the failed event titles for the admin flash" do
+      stub_request(:get, image_url).to_return(status: 404)
+
+      expect(Rails.cache).to receive(:write).with(
+        "events_image_error", ["Image Event"], hash_including(:expires_in)
+      )
+
+      described_class.call(response_body: image_body)
+    end
   end
 
   describe "remote request date window" do


### PR DESCRIPTION
Admin::EventsController#sync dumped the whole cached failure list into flash[:notice]. Flash is serialized into the session cookie, which Rack caps at 4kb, so a sync with ~38 image failures raised CookieOverflow and the admin lost the sync result entirely. 

The service now caches the failed titles as an array rather than a rendered HTML string, and the controller names the first five and points at log/sync-libcal-event.log for the rest.