### PR TITLE
MAN-1553-switch-events-harvest-source-to-lib-cal

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  has_paper_trail
   include Categorizable
   include Imageable
   include InputCleaner

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -36,11 +36,6 @@ RSpec.describe Admin::EventsController, type: :controller do
       get :edit, params: { id: @event.to_param }
       expect(response.body).to match(updated_title)
     end
-
-    it "renders edit form with original values when selected" do
-      get :edit, params: { id: @event.to_param, version: @event.versions.last.to_param }
-      expect(response.body).to match(original_title)
-    end
   end
 
   describe "GET #index" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -72,42 +72,6 @@ RSpec.describe Event, type: :model do
     end
   end
 
-  describe "version all fields" do
-    fields = {
-      title: ["The Text 1", "The Text 2"],
-      description: [ActionText::Content.new("Hello World"), ActionText::Content.new("Goodbye, Cruel World")],
-      start_time: [Time.zone.parse("2018/9/24 11:00"), Time.zone.parse("2018/9/24 11:30")],
-      end_time: [Time.zone.parse("2018/9/24 12:00"), Time.zone.parse("2018/9/24 12:30")],
-      location_name: ["The Text 1", "The Text 2"],
-      location_space: ["The Text 1", "The Text 2"],
-      address: ["The Text 1", "The Text 2"],
-      city: ["The Text 1", "The Text 2"],
-      state: ["The Text 1", "The Text 2"],
-      zip: ["The Text 1", "The Text 2"],
-      contact_name: ["The Text 1", "The Text 2"],
-      contact_email: ["The Text 1", "The Text 2"],
-      contact_phone: ["The Text 1", "The Text 2"],
-      cancelled: [false, true],
-      registration_status: [true, false],
-      registration_link: ["https://example.com/reg1", "https://example.com/reg2"],
-      content_hash: ["The Text 1", "The Text 2"],
-      alt_text: ["The Text 1", "The Text 2"],
-      ensemble_identifier: ["The Text 1", "The Text 2"],
-      tags: ["tag1, tag2", "tag3, tag4"],
-      all_day: [false, true]
-    }
-
-    fields.each do |k, v|
-      example "#{k} changes" do
-        next if k == :description # Description is not versionable
-        event = FactoryBot.create(:event, k => v.first)
-        event.update(k => v.last)
-        event.save!
-        expect(event.versions.last.changeset[k]).to match_array(v)
-      end
-    end
-  end
-
   describe "mapping to schema.org" do
     let(:event) { FactoryBot.create(:event) }
 


### PR DESCRIPTION
Removes the versioning (via paperclip gem) from the Events model.