### PR TITLE
MAN-1570-add-alt-text-to-images-on-individual-events-pages-other-website-locations

### DIFF
--- a/app/helpers/event_helper.rb
+++ b/app/helpers/event_helper.rb
@@ -3,6 +3,24 @@
 require "json/ld"
 
 module EventHelper
+  def render_event_image(event, variant: :show)
+    if variant == :index
+      html_class = nil
+      sized_image = -> { event.index_image }
+      linked = true
+    else
+      html_class = "img-fluid event-show-image"
+      sized_image = -> { event.fit_image(600, 600) }
+      linked = false
+    end
+
+    return image_tag("T.png", alt: "Temple T Logo") unless event.image.attached?
+
+    alt_text = event.alt_text.presence || "Event image for #{event.title}"
+    image = image_tag(sized_image.call, class: html_class, alt: alt_text)
+    linked ? link_to(image, event_path(event.id), target: "_top") : image
+  end
+
   def render_event_location(event)
     location_link = event_location_link(event)
     return if location_link.blank?

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -3,11 +3,7 @@
   <div class="col-12 col-md-4 col-lg-6 event">
     <div class="row mb-4 pe-2">
       <div class="col-12 col-lg-4 mb-3">
-      <% if event.image.attached? %>
-        <%= link_to (image_tag event.index_image, class: "decorative", alt: ""), event_path(event.id), target: "_top" %>
-      <% else %>
-        <%= image_tag 'T.png', class: "decorative", alt: "" %>
-      <% end %>
+        <%= render_event_image(event, variant: :index) %>
       </div>
       <div class="col-12 col-lg-8">
         <%= link_to event.title.truncate(42), event_path(event.id), class: "event-title", target: "_top" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,11 +10,7 @@
   <div class="row">
 
     <div class="col-12 col-lg-3 text-center">
-      <% if @event.image.attached? %>
-          <%= image_tag @event.fit_image(600, 600), class: "decorative img-fluid event-show-image", alt: "" %>
-        <% else %>
-          <%= image_tag 'T.png', class: "decorative img-fluid event-show-image", alt: "" %>
-        <% end %>
+      <%= render_event_image(@event) %>
     </div>
 
     <div class="col-12 col-lg-6 event-info">

--- a/spec/helpers/event_helper_spec.rb
+++ b/spec/helpers/event_helper_spec.rb
@@ -155,4 +155,39 @@ RSpec.describe EventHelper, type: :helper do
       expect(helper.filters_link("past")).to include(t("manifold.events.index.view_past_events_link"))
     end
   end
+
+  describe "render_event_image" do
+    it "uses the feed-supplied alt text on an attached image" do
+      event = FactoryBot.create(:event, :with_image, alt_text: "A descriptive caption")
+      expect(helper.render_event_image(event)).to include('alt="A descriptive caption"')
+    end
+
+    it "falls back to a title-based alt when an attached image has no feed alt text" do
+      event = FactoryBot.create(:event, :with_image, title: "Poetry Reading", alt_text: nil)
+      expect(helper.render_event_image(event)).to include('alt="Event image for Poetry Reading"')
+    end
+
+    it "renders the Temple T placeholder with a descriptive alt when no image is attached" do
+      event = FactoryBot.create(:event, alt_text: "Ignored without an image")
+      html = helper.render_event_image(event)
+      expect(html).to match(%r{assets/T})
+      expect(html).to include('alt="Temple T Logo"')
+    end
+
+    context "index variant" do
+      it "links the attached image to the event and carries the alt text" do
+        event = FactoryBot.create(:event, :with_image, alt_text: "Thumbnail caption")
+        html = helper.render_event_image(event, variant: :index)
+        expect(html).to include('alt="Thumbnail caption"')
+        expect(html).to include(%Q(href="#{event_path(event.id)}"))
+      end
+
+      it "falls back to the Temple T placeholder when no image is attached" do
+        event = FactoryBot.create(:event)
+        html = helper.render_event_image(event, variant: :index)
+        expect(html).to match(%r{assets/T})
+        expect(html).to include('alt="Temple T Logo"')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Event images were rendering with empty alt text on the show page and the events list partial, and consolidates the duplicated conditional out of both templates into a render_event_image helper that supplies a meaningful alt: the feed's alt_text when present, an "Event image for {title}" fallback for attached images without supplied alt_text, and "Temple T Logo" for the default placeholder when no image is attached. 